### PR TITLE
enhance: Object.value|entries supports a generic Record type

### DIFF
--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -5,32 +5,17 @@ interface ObjectConstructor {
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  values<T>(
-    o: T
-  ): string | number extends keyof T
-    ? T[string | number][]
-    : string extends keyof T
-    ? T[string][]
-    : number extends keyof T
-    ? T[number][]
-    : unknown[];
+  values<T>(o: ArrayLike<T>): T[];
+  values<K extends string | number | symbol, V>(o: Record<K, V>): V[];
+  values(o: unknown): unknown[];
 
   /**
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<T>(
-    o: T
-  ): [
-    string,
-    string | number extends keyof T
-      ? T[string | number]
-      : string extends keyof T
-      ? T[string]
-      : number extends keyof T
-      ? T[number]
-      : unknown
-  ][];
+  entries<T>(o: ArrayLike<T>): [string, T][];
+  entries<K extends string | number | symbol, V>(o: Record<K, V>): [string, V][];
+  entries<T>(o: T): [string, unknown][];
 
   /**
    * Returns an object containing all own property descriptors of an object

--- a/tests/es2017.object.ts
+++ b/tests/es2017.object.ts
@@ -2,12 +2,16 @@
 
 import { expectType } from "tsd";
 
+function createGenericRecord<K extends string, V>(keys: K[], values: V[]): Record<K, V> {
+  return Object.fromEntries(keys.map((k, i) => [k, values[i]!] as const));
+}
+
 {
-  const obj1 = { foo: 123 };
+  const obj1: {[k: string]: number} = { foo: 123 };
   const values1 = Object.values(obj1);
   const entries1 = Object.entries(obj1);
-  expectType<unknown[]>(values1);
-  expectType<[string, unknown][]>(entries1);
+  expectType<number[]>(values1);
+  expectType<[string, number][]>(entries1);
 
   const obj2: Record<string, number> = {};
   const values2 = Object.values(obj2);
@@ -20,6 +24,18 @@ import { expectType } from "tsd";
   const entries3 = Object.entries(obj3);
   expectType<string[]>(values3);
   expectType<[string, string][]>(entries3);
+
+  const obj4 = createGenericRecord(["foo", "bar", "baz"], [1, 2, 3]);
+  const values4 = Object.values(obj4);
+  const entries4 = Object.entries(obj4);
+  expectType<number[]>(values4);
+  expectType<[string, number][]>(entries4);
+
+  const obj5 = createGenericRecord(["foo", "bar", "baz"], [1, obj1, 3]);
+  const values5 = Object.values(obj5);
+  const entries5 = Object.entries(obj5);
+  expectType<(number | {[k: string]: number})[]>(values5);
+  expectType<[string, (number | {[k: string]: number})][]>(entries5);
 }
 function test<T>(obj: T) {
   const values = Object.values(obj);


### PR DESCRIPTION
## Overview

Add type support for `Record<K, V>` like below:

```typescript
function x<K extends string, V>(arg: Record<K, V>): readonly V[] {
  return Object.values(arg);
}
```

### Expected result

Works 👌 

### Actual result

```
Type 'unknown[] | Record<K, V>[K & (string | number | symbol)][] | Record<K, V>[K & string][] | Record<K, V>[K & number][]' is not assignable to type 'readonly V[]'.
```

## Note

I tried to add a conditional type infer for that but doesn't work. :(

```typescript
  T extends Record<any, infer V> 
    ? V[]
    : string | number extends keyof T
    ? T[string | number][]
    : string extends keyof T
    ? T[string][]
    : number extends keyof T
    ? T[number][]
    : unknown[];
```

So I use overload to fix this issue.
