### PR TITLE
Improvement in Object.entries type definition

### DIFF
--- a/generated/lib.es2017.object.d.ts
+++ b/generated/lib.es2017.object.d.ts
@@ -14,7 +14,24 @@ interface ObjectConstructor {
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
   entries<T>(o: ArrayLike<T>): [string, T][];
-  entries<K extends string | number | symbol, V>(o: Record<K, V>): [string, V][];
+  entries<T, V = unknown>(
+    o: T
+  ): (T extends new (...args: any[]) => any
+    ? // T is a class constructor
+      [string, V]
+    : T[keyof T] extends Exclude<T[keyof T], CallableFunction>
+    ? string | number extends keyof T
+      ? // T is Record<string | number, x>; avoid ([string, x] | [`${number}`, x])[]
+        [string, T[string | number]]
+      : keyof T extends infer K
+      ? K extends keyof T
+        ? K extends string | number
+          ? [`${K}`, T[K]]
+          : never
+        : never
+      : never
+    : // some of T's property is a function, which is not enumerable in many cases
+      [string, V])[];
   entries<T>(o: T): [string, unknown][];
 
   /**

--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -14,7 +14,24 @@ interface ObjectConstructor {
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
   entries<T>(o: ArrayLike<T>): [string, T][];
-  entries<K extends string | number | symbol, V>(o: Record<K, V>): [string, V][];
+  entries<T, V = unknown>(
+    o: T
+  ): (T extends new (...args: any[]) => any
+    ? // T is a class constructor
+      [string, V]
+    : T[keyof T] extends Exclude<T[keyof T], CallableFunction>
+    ? string | number extends keyof T
+      ? // T is Record<string | number, x>; avoid ([string, x] | [`${number}`, x])[]
+        [string, T[string | number]]
+      : keyof T extends infer K
+      ? K extends keyof T
+        ? K extends string | number
+          ? [`${K}`, T[K]]
+          : never
+        : never
+      : never
+    : // some of T's property is a function, which is not enumerable in many cases
+      [string, V])[];
   entries<T>(o: T): [string, unknown][];
 
   /**

--- a/tests/src/es2017.object.ts
+++ b/tests/src/es2017.object.ts
@@ -30,13 +30,15 @@ function createGenericRecord<K extends string, V>(
   const values4 = Object.values(obj4);
   const entries4 = Object.entries(obj4);
   expectType<number[]>(values4);
-  expectType<[string, number][]>(entries4);
+  expectType<(["foo", number] | ["bar", number] | ["baz", number])[]>(entries4);
 
-  const obj5 = createGenericRecord(["foo", "bar", "baz"], [1, obj1, 3]);
+  const obj5 = { foo: 1, bar: obj1, baz: 3 };
   const values5 = Object.values(obj5);
   const entries5 = Object.entries(obj5);
   expectType<(number | { [k: string]: number })[]>(values5);
-  expectType<[string, number | { [k: string]: number }][]>(entries5);
+  expectType<
+    (["foo", number] | ["baz", number] | ["bar", { [k: string]: number }])[]
+  >(entries5);
 }
 function test<T>(obj: T) {
   const values = Object.values(obj);

--- a/tests/src/es2017.object.ts
+++ b/tests/src/es2017.object.ts
@@ -39,6 +39,51 @@ function createGenericRecord<K extends string, V>(
   expectType<
     (["foo", number] | ["baz", number] | ["bar", { [k: string]: number }])[]
   >(entries5);
+
+  const hasDifferentTypeOfKeys = {
+    foo: "bar",
+    123: 456,
+    [Symbol.iterator]: Symbol.asyncIterator,
+  };
+  const entries6 = Object.entries(hasDifferentTypeOfKeys);
+  expectType<(["foo", string] | ["123", number])[]>(entries6);
+
+  const ClassConstructor = class {
+    foo = "bar";
+    baz = 123;
+  };
+  const entries7 = Object.entries(ClassConstructor);
+  expectType<[string, unknown][]>(entries7);
+
+  const classInstance = new ClassConstructor();
+  const entries8 = Object.entries(classInstance);
+  expectType<(["baz", number] | ["foo", string])[]>(entries8);
+
+  const classWithMethodInstance = new (class ClassWithMethod {
+    foo() {
+      return 123;
+    }
+  })();
+  const entries9 = Object.entries(classWithMethodInstance);
+  expectType<[string, unknown][]>(entries9);
+
+  const date = new Date();
+  const entries10 = Object.entries(date);
+  expectType<[string, unknown][]>(entries10);
+
+  const objectWithMethod = {
+    foo: "bar",
+    baz() {
+      return 123;
+    },
+  };
+  const entries11 = Object.entries(objectWithMethod);
+  expectType<[string, unknown][]>(entries11);
+  const entries12 = Object.entries<
+    typeof objectWithMethod,
+    typeof objectWithMethod[keyof typeof objectWithMethod]
+  >(objectWithMethod);
+  expectType<[string, string | (() => number)][]>(entries12);
 }
 function test<T>(obj: T) {
   const values = Object.values(obj);


### PR DESCRIPTION
This PR (hopefully) introduces an improvement in `Object.entries` type definition.

It enables:

```ts
const hasDifferentTypeOfKeys = {
  foo: 'bar',
  123: 456,
  [Symbol.iterator]: Symbol.asyncIterator,
};

for (const entry of Object.entries(hasDifferentTypeOfKeys)) {
  if (entry[0] === 'foo') {
    // now we know the value is string
    console.log(entry[1].toUpperCase());
  } else {
    // now we know the value is number
    console.log(entry[1].toFixed(3));
  }
}
```

Since applying `Object.entries` on things like `new Date()`, `Date`, `class X {}`, `new X()`, etc. is a bit tricky (what complicates the situation is `Object.entries` enumerates only enumerable props but TypeScript `keyof` lists everything), the new definition is still not perfect.
Nevertheless at least it does not make anything worse, as the type of values would fallback to `V`, which defaults to `unknown`, and can be explicitly specified if you want, in such complex cases.

Hope this helps!
// but if you feel like "I don't like this somehow", don't hesitate to simply reject it :)