### PR TITLE
Major Improvements 2

### DIFF
--- a/build/alias.ts
+++ b/build/alias.ts
@@ -1,0 +1,46 @@
+const aliasArray: [string, string[]][] = [
+  [
+    "TypedNumberArray",
+    [
+      "Int8Array",
+      "Uint8Array",
+      "Uint8ClampedArray",
+      "Int16Array",
+      "Uint16Array",
+      "Int32Array",
+      "Uint32Array",
+      "Float32Array",
+      "Float64Array",
+    ],
+  ],
+  ["TypedBigIntArray", ["BigInt64Array", "BigUint64Array"]],
+];
+
+export const alias = new Map(
+  aliasArray.flatMap(([originalType, replacementTypes]) => [
+    [
+      originalType,
+      new Map(
+        replacementTypes.map((replacement) => [
+          replacement,
+          new Map([
+            [originalType, replacement],
+            [`${originalType}Constructor`, `${replacement}Constructor`],
+          ]),
+        ])
+      ),
+    ],
+    [
+      `${originalType}Constructor`,
+      new Map(
+        replacementTypes.map((replacement) => [
+          `${replacement}Constructor`,
+          new Map([
+            [originalType, replacement],
+            [`${originalType}Constructor`, `${replacement}Constructor`],
+          ]),
+        ])
+      ),
+    ],
+  ])
+);

--- a/docs/diff.md
+++ b/docs/diff.md
@@ -15,6 +15,7 @@ The following files are improved in better-typescript-lib:
 - [es2018.asyncgenerator.d.ts](./diff/es2018.asyncgenerator.d.ts.md)
 - [es2018.asynciterable.d.ts](./diff/es2018.asynciterable.d.ts.md)
 - [es2019.object.d.ts](./diff/es2019.object.d.ts.md)
+- [es2020.bigint.d.ts](./diff/es2020.bigint.d.ts.md)
 - [es2021.promise.d.ts](./diff/es2021.promise.d.ts.md)
 - [es2021.string.d.ts](./diff/es2021.string.d.ts.md)
 - [es2022.object.d.ts](./diff/es2022.object.d.ts.md)

--- a/docs/diff/es2015.collection.d.ts.md
+++ b/docs/diff/es2015.collection.d.ts.md
@@ -13,7 +13,7 @@ Index: es2015.collection.d.ts
 -    callbackfn: (value: V, key: K, map: Map<K, V>) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (this: This, value: V, key: K, map: Map<K, V>) => void,
++    callbackfn: (this: This, value: V, key: K, map: this) => void,
 +    thisArg?: This
    ): void;
    get(key: K): V | undefined;
@@ -35,7 +35,7 @@ Index: es2015.collection.d.ts
 -    callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (this: This, value: V, key: K, map: ReadonlyMap<K, V>) => void,
++    callbackfn: (this: This, value: V, key: K, map: this) => void,
 +    thisArg?: This
    ): void;
    get(key: K): V | undefined;
@@ -66,7 +66,7 @@ Index: es2015.collection.d.ts
 -    callbackfn: (value: T, value2: T, set: Set<T>) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (this: This, value: T, value2: T, set: Set<T>) => void,
++    callbackfn: (this: This, value: T, value2: T, set: this) => void,
 +    thisArg?: This
    ): void;
    has(value: T): boolean;
@@ -86,7 +86,7 @@ Index: es2015.collection.d.ts
 -    callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (this: This, value: T, value2: T, set: ReadonlySet<T>) => void,
++    callbackfn: (this: This, value: T, value2: T, set: this) => void,
 +    thisArg?: This
    ): void;
    has(value: T): boolean;

--- a/docs/diff/es2015.core.d.ts.md
+++ b/docs/diff/es2015.core.d.ts.md
@@ -5,7 +5,90 @@ Index: es2015.core.d.ts
 ===================================================================
 --- es2015.core.d.ts
 +++ es2015.core.d.ts
-@@ -201,44 +201,42 @@
+@@ -7,15 +7,25 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find<S extends T>(
+-    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
+-    thisArg?: any
++  find<S extends T, This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => value is S,
++    thisArg?: This
+   ): S | undefined;
+-  find(
+-    predicate: (value: T, index: number, obj: T[]) => unknown,
+-    thisArg?: any
++
++  /**
++   * Returns the value of the first element in the array where predicate is true, and undefined
++   * otherwise.
++   * @param predicate find calls predicate once for each element of the array, in ascending
++   * order, until it finds one where predicate returns true. If such an element is found, find
++   * immediately returns that element value. Otherwise, find returns undefined.
++   * @param thisArg If provided, it will be used as the this value for each invocation of
++   * predicate. If it is not provided, undefined is used instead.
++   */
++  find<This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): T | undefined;
+ 
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+@@ -25,11 +35,11 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: T, index: number, obj: T[]) => unknown,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -51,26 +61,25 @@
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+ }
+-
+ interface ArrayConstructor {
+   /**
+-   * Creates an array from an array-like object.
+-   * @param arrayLike An array-like object to convert to an array.
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from<T>(arrayLike: ArrayLike<T>): T[];
++  from<T>(source: ArrayLike<T>): T[];
+ 
+   /**
+-   * Creates an array from an iterable object.
+-   * @param arrayLike An array-like object to convert to an array.
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T, U>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => U,
+-    thisArg?: any
++  from<T, U, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => U,
++    thisArg?: This
+   ): U[];
+ 
+   /**
+    * Returns a new array from a set of elements.
+@@ -201,44 +210,42 @@
     * @param x A numeric expression.
     */
    cbrt(x: number): number;
@@ -54,7 +137,7 @@ Index: es2015.core.d.ts
    /**
     * The value of the largest integer n such that n and n + 1 are both exactly representable as
     * a Number value.
-@@ -267,51 +265,21 @@
+@@ -267,51 +274,31 @@
     * All other strings are considered decimal.
     */
    parseInt(string: string, radix?: number): number;
@@ -95,7 +178,17 @@ Index: es2015.core.d.ts
 -    source3: W
 -  ): T & U & V & W;
 +    ...sources: Ts
-+  ): First<UnionToIntersection<[T] | { [K in keyof Ts]: [Ts[K]] }[number]>>;
++  ): CheckNonNullable<
++    T,
++    First<
++      UnionToIntersection<
++        | [T]
++        | {
++            [K in keyof Ts]: [Ts[K]];
++          }[number]
++      >
++    >
++  >;
  
    /**
 -   * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -110,7 +203,7 @@ Index: es2015.core.d.ts
     * @param o Object to retrieve the symbols from.
     */
    getOwnPropertySymbols(o: any): symbol[];
-@@ -326,16 +294,23 @@
+@@ -326,18 +313,24 @@
     * Returns true if the values are the same value, false otherwise.
     * @param value1 The first value.
     * @param value2 The second value.
@@ -133,10 +226,64 @@ Index: es2015.core.d.ts
 +   */
 +  setPrototypeOf<T extends object>(o: T, proto: null): T;
  }
- 
+-
  interface ReadonlyArray<T> {
    /**
-@@ -407,9 +382,8 @@
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+@@ -346,20 +339,25 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find<S extends T>(
+-    predicate: (
+-      this: void,
+-      value: T,
+-      index: number,
+-      obj: readonly T[]
+-    ) => value is S,
+-    thisArg?: any
++  find<S extends T, This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => value is S,
++    thisArg?: This
+   ): S | undefined;
+-  find(
+-    predicate: (value: T, index: number, obj: readonly T[]) => unknown,
+-    thisArg?: any
++
++  /**
++   * Returns the value of the first element in the array where predicate is true, and undefined
++   * otherwise.
++   * @param predicate find calls predicate once for each element of the array, in ascending
++   * order, until it finds one where predicate returns true. If such an element is found, find
++   * immediately returns that element value. Otherwise, find returns undefined.
++   * @param thisArg If provided, it will be used as the this value for each invocation of
++   * predicate. If it is not provided, undefined is used instead.
++   */
++  find<This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): T | undefined;
+ 
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+@@ -369,11 +367,11 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: T, index: number, obj: readonly T[]) => unknown,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: T, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+ }
+ 
+ interface RegExp {
+@@ -407,9 +405,8 @@
  interface RegExpConstructor {
    new (pattern: RegExp | string, flags?: string): RegExp;
    (pattern: RegExp | string, flags?: string): RegExp;
@@ -146,7 +293,7 @@ Index: es2015.core.d.ts
    /**
     * Returns a nonnegative integer Number less than 1114112 (0x110000) that is the code point
     * value of the UTF-16 encoded code point starting at the string element at position pos in
-@@ -433,26 +407,17 @@
+@@ -433,26 +430,17 @@
     * same as the corresponding elements of this object (converted to a String) starting at
     * endPosition – length(this). Otherwise returns false.
     */

--- a/docs/diff/es2015.iterable.d.ts.md
+++ b/docs/diff/es2015.iterable.d.ts.md
@@ -28,7 +28,43 @@ Index: es2015.iterable.d.ts
  }
  
  interface Array<T> {
-@@ -95,12 +94,11 @@
+@@ -55,26 +54,25 @@
+    * Returns an iterable of values in the array
+    */
+   values(): IterableIterator<T>;
+ }
+-
+ interface ArrayConstructor {
+   /**
+-   * Creates an array from an iterable object.
+-   * @param iterable An iterable object to convert to an array.
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from<T>(iterable: Iterable<T> | ArrayLike<T>): T[];
++  from<T>(source: Iterable<T> | ArrayLike<T>): T[];
+ 
+   /**
+-   * Creates an array from an iterable object.
+-   * @param iterable An iterable object to convert to an array.
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T, U>(
+-    iterable: Iterable<T> | ArrayLike<T>,
+-    mapfn: (v: T, k: number) => U,
+-    thisArg?: any
++  from<T, U, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => U,
++    thisArg?: This
+   ): U[];
+ }
+ 
+ interface ReadonlyArray<T> {
+@@ -95,12 +93,11 @@
     * Returns an iterable of values in the array
     */
    values(): IterableIterator<T>;
@@ -42,7 +78,7 @@ Index: es2015.iterable.d.ts
  
  interface Map<K, V> {
    /** Returns an iterable of entries in the map. */
-@@ -140,11 +138,9 @@
+@@ -140,11 +137,9 @@
     * Returns an iterable of values in the map
     */
    values(): IterableIterator<V>;
@@ -54,7 +90,7 @@ Index: es2015.iterable.d.ts
  }
  
  interface WeakMap<K extends object, V> {}
-@@ -201,25 +197,24 @@
+@@ -201,25 +196,24 @@
    new <T extends object = object>(iterable: Iterable<T>): WeakSet<T>;
  }
  
@@ -82,5 +118,300 @@ Index: es2015.iterable.d.ts
  
  interface String {
    /** Iterator */
+@@ -240,22 +234,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Int8ArrayConstructor {
+   new (elements: Iterable<number>): Int8Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Int8Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int8Array;
+ }
+ 
+ interface Uint8Array {
+@@ -272,22 +269,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Uint8ArrayConstructor {
+   new (elements: Iterable<number>): Uint8Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Uint8Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint8Array;
+ }
+ 
+ interface Uint8ClampedArray {
+@@ -306,22 +306,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Uint8ClampedArrayConstructor {
+   new (elements: Iterable<number>): Uint8ClampedArray;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Uint8ClampedArray;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint8ClampedArray;
+ }
+ 
+ interface Int16Array {
+@@ -340,22 +343,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Int16ArrayConstructor {
+   new (elements: Iterable<number>): Int16Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Int16Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int16Array;
+ }
+ 
+ interface Uint16Array {
+@@ -372,22 +378,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Uint16ArrayConstructor {
+   new (elements: Iterable<number>): Uint16Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Uint16Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint16Array;
+ }
+ 
+ interface Int32Array {
+@@ -404,22 +413,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Int32ArrayConstructor {
+   new (elements: Iterable<number>): Int32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Int32Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int32Array;
+ }
+ 
+ interface Uint32Array {
+@@ -436,22 +448,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Uint32ArrayConstructor {
+   new (elements: Iterable<number>): Uint32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Uint32Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint32Array;
+ }
+ 
+ interface Float32Array {
+@@ -468,22 +483,25 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Float32ArrayConstructor {
+   new (elements: Iterable<number>): Float32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Float32Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Float32Array;
+ }
+ 
+ interface Float64Array {
+@@ -500,20 +518,23 @@
+    * Returns an list of values in the array
+    */
+   values(): IterableIterator<number>;
+ }
+-
+ interface Float64ArrayConstructor {
+   new (elements: Iterable<number>): Float64Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
++   */
++  from(source: Iterable<number> | ArrayLike<number>): Float64Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(
+-    arrayLike: Iterable<number>,
+-    mapfn?: (v: number, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Float64Array;
+ }
 
 ```

--- a/docs/diff/es2015.symbol.wellknown.d.ts.md
+++ b/docs/diff/es2015.symbol.wellknown.d.ts.md
@@ -5,7 +5,7 @@ Index: es2015.symbol.wellknown.d.ts
 ===================================================================
 --- es2015.symbol.wellknown.d.ts
 +++ es2015.symbol.wellknown.d.ts
-@@ -69,23 +69,14 @@
+@@ -69,22 +69,15 @@
    [Symbol.toPrimitive](hint: string): symbol;
  
    readonly [Symbol.toStringTag]: string;
@@ -24,13 +24,13 @@ Index: es2015.symbol.wellknown.d.ts
 -    findIndex: boolean;
 -    keys: boolean;
 -    values: boolean;
--  };
-+  readonly [Symbol.unscopables]: { [key: PropertyKey]: boolean };
++  readonly [Symbol.unscopables]: {
++    [key: PropertyKey]: boolean;
+   };
  }
  
  interface Date {
-   /**
-@@ -156,17 +147,15 @@
+@@ -156,17 +149,15 @@
  
  interface PromiseConstructor {
    readonly [Symbol.species]: PromiseConstructor;
@@ -48,7 +48,7 @@ Index: es2015.symbol.wellknown.d.ts
     * Replaces text in a string, using this regular expression.
     * @param string A String object or string literal whose contents matching against
     *               this regular expression will be replaced
-@@ -182,9 +171,14 @@
+@@ -182,9 +173,14 @@
     * @param replacer A function that returns the replacement text.
     */
    [Symbol.replace](
@@ -64,7 +64,7 @@ Index: es2015.symbol.wellknown.d.ts
  
    /**
     * Finds the position beginning first substring match in a regular expression search
-@@ -211,9 +205,8 @@
+@@ -211,9 +207,8 @@
  
  interface RegExpConstructor {
    readonly [Symbol.species]: RegExpConstructor;
@@ -74,7 +74,7 @@ Index: es2015.symbol.wellknown.d.ts
    /**
     * Matches a string or an object that supports being matched against, and returns an array
     * containing the results of that search, or null if no matches are found.
-@@ -221,12 +214,11 @@
+@@ -221,12 +216,11 @@
     */
    match(matcher: {
      [Symbol.match](string: string): RegExpMatchArray | null;
@@ -88,7 +88,7 @@ Index: es2015.symbol.wellknown.d.ts
     */
    replace(
      searchValue: {
-@@ -243,12 +235,12 @@
+@@ -243,12 +237,12 @@
    replace(
      searchValue: {
        [Symbol.replace](

--- a/docs/diff/es2017.object.d.ts.md
+++ b/docs/diff/es2017.object.d.ts.md
@@ -5,7 +5,7 @@ Index: es2017.object.d.ts
 ===================================================================
 --- es2017.object.d.ts
 +++ es2017.object.d.ts
-@@ -2,27 +2,35 @@
+@@ -2,34 +2,45 @@
    /**
     * Returns an array of values of the enumerable properties of an object
     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -23,7 +23,7 @@ Index: es2017.object.d.ts
 +   * Returns an array of values of the enumerable properties of an object
 +   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 +   */
-+  values(o: unknown): unknown[];
++  values<T>(o: T): CheckNonNullable<T, unknown[]>;
  
    /**
     * Returns an array of key/values of the enumerable properties of an object
@@ -42,10 +42,25 @@ Index: es2017.object.d.ts
 +   * Returns an array of key/values of the enumerable properties of an object
 +   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 +   */
-+  entries<T>(o: T): [string, unknown][];
++  entries<T>(o: T): CheckNonNullable<T, [string, unknown][]>;
  
    /**
     * Returns an object containing all own property descriptors of an object
     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+    */
+-  getOwnPropertyDescriptors<T>(
+-    o: T
+-  ): { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & {
+-    [x: string]: PropertyDescriptor;
+-  };
++  getOwnPropertyDescriptors<T>(o: T): CheckNonNullable<
++    T,
++    {
++      [P in keyof T]: TypedPropertyDescriptor<T[P]>;
++    } & {
++      [x: string]: PropertyDescriptor;
++    }
++  >;
+ }
 
 ```

--- a/docs/diff/es2020.bigint.d.ts.md
+++ b/docs/diff/es2020.bigint.d.ts.md
@@ -1,0 +1,636 @@
+# es2020.bigint.d.ts Diffs
+
+```diff
+Index: es2020.bigint.d.ts
+===================================================================
+--- es2020.bigint.d.ts
++++ es2020.bigint.d.ts
+@@ -228,13 +228,8 @@
+   asUintN(bits: number, int: bigint): bigint;
+ }
+ 
+ declare var BigInt: BigIntConstructor;
+-
+-/**
+- * A typed array of 64-bit signed integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated, an exception is raised.
+- */
+ interface BigInt64Array {
+   /** The size in bytes of each element in the array. */
+   readonly BYTES_PER_ELEMENT: number;
+ 
+@@ -259,20 +254,24 @@
+   copyWithin(target: number, start: number, end?: number): this;
+ 
+   /** Yields index, value pairs for every entry in the array. */
+   entries(): IterableIterator<[number, bigint]>;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns false,
+    * or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -282,21 +281,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: bigint, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: bigint, index: number, array: BigInt64Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): BigInt64Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -304,13 +306,17 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): bigint | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -318,23 +324,27 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: bigint, index: number, array: BigInt64Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: bigint, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Determines whether an array includes a certain element, returning true or false as appropriate.
+@@ -370,41 +380,40 @@
+   lastIndexOf(searchElement: bigint, fromIndex?: number): number;
+ 
+   /** The length of the array. */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: bigint, index: number, array: BigInt64Array) => bigint,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => bigint,
++    thisArg?: This
+   ): BigInt64Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = bigint>(
+     callbackfn: (
+-      previousValue: bigint,
++      previousValue: bigint | U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigInt64Array
+-    ) => bigint
+-  ): bigint;
+-
++      array: this
++    ) => U
++  ): bigint | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -413,37 +422,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = bigint>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigInt64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = bigint>(
+     callbackfn: (
+-      previousValue: bigint,
++      previousValue: bigint | U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigInt64Array
+-    ) => bigint
+-  ): bigint;
+-
++      array: this
++    ) => U
++  ): bigint | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -452,14 +456,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = bigint>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigInt64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -478,20 +482,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array.
+    */
+   slice(start?: number, end?: number): BigInt64Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls the
+    * predicate function for each element in the array until the predicate returns true, or until
+    * the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts the array.
+@@ -524,9 +532,8 @@
+   readonly [Symbol.toStringTag]: "BigInt64Array";
+ 
+   [index: number]: bigint;
+ }
+-
+ interface BigInt64ArrayConstructor {
+   readonly prototype: BigInt64Array;
+   new (length?: number): BigInt64Array;
+   new (array: Iterable<bigint>): BigInt64Array;
+@@ -543,29 +550,27 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: bigint[]): BigInt64Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+    * @param arrayLike An array-like or iterable object to convert to an array.
++   */
++  from(arrayLike: Iterable<bigint> | ArrayLike<bigint>): BigInt64Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param arrayLike An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(arrayLike: ArrayLike<bigint>): BigInt64Array;
+-  from<U>(
+-    arrayLike: ArrayLike<U>,
+-    mapfn: (v: U, k: number) => bigint,
+-    thisArg?: any
++  from<T, This = undefined>(
++    arrayLike: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => bigint,
++    thisArg?: This
+   ): BigInt64Array;
+ }
+ 
+ declare var BigInt64Array: BigInt64ArrayConstructor;
+-
+-/**
+- * A typed array of 64-bit unsigned integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated, an exception is raised.
+- */
+ interface BigUint64Array {
+   /** The size in bytes of each element in the array. */
+   readonly BYTES_PER_ELEMENT: number;
+ 
+@@ -590,20 +595,24 @@
+   copyWithin(target: number, start: number, end?: number): this;
+ 
+   /** Yields index, value pairs for every entry in the array. */
+   entries(): IterableIterator<[number, bigint]>;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns false,
+    * or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -613,21 +622,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: bigint, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: bigint, index: number, array: BigUint64Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): BigUint64Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -635,13 +647,17 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): bigint | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -649,23 +665,27 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: bigint, index: number, array: BigUint64Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: bigint, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Determines whether an array includes a certain element, returning true or false as appropriate.
+@@ -701,41 +721,40 @@
+   lastIndexOf(searchElement: bigint, fromIndex?: number): number;
+ 
+   /** The length of the array. */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: bigint, index: number, array: BigUint64Array) => bigint,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => bigint,
++    thisArg?: This
+   ): BigUint64Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = bigint>(
+     callbackfn: (
+-      previousValue: bigint,
++      previousValue: bigint | U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigUint64Array
+-    ) => bigint
+-  ): bigint;
+-
++      array: this
++    ) => U
++  ): bigint | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -744,37 +763,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = bigint>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigUint64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = bigint>(
+     callbackfn: (
+-      previousValue: bigint,
++      previousValue: bigint | U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigUint64Array
+-    ) => bigint
+-  ): bigint;
+-
++      array: this
++    ) => U
++  ): bigint | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -783,14 +797,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = bigint>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: bigint,
+       currentIndex: number,
+-      array: BigUint64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -809,20 +823,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array.
+    */
+   slice(start?: number, end?: number): BigUint64Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls the
+    * predicate function for each element in the array until the predicate returns true, or until
+    * the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: bigint,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts the array.
+@@ -855,9 +873,8 @@
+   readonly [Symbol.toStringTag]: "BigUint64Array";
+ 
+   [index: number]: bigint;
+ }
+-
+ interface BigUint64ArrayConstructor {
+   readonly prototype: BigUint64Array;
+   new (length?: number): BigUint64Array;
+   new (array: Iterable<bigint>): BigUint64Array;
+@@ -874,20 +891,23 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: bigint[]): BigUint64Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+    * @param arrayLike An array-like or iterable object to convert to an array.
++   */
++  from(arrayLike: Iterable<bigint> | ArrayLike<bigint>): BigUint64Array;
++  /**
++   * Creates an array from an array-like or iterable object.
++   * @param arrayLike An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from(arrayLike: ArrayLike<bigint>): BigUint64Array;
+-  from<U>(
+-    arrayLike: ArrayLike<U>,
+-    mapfn: (v: U, k: number) => bigint,
+-    thisArg?: any
++  from<T, This = undefined>(
++    arrayLike: Iterable<T> | ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => bigint,
++    thisArg?: This
+   ): BigUint64Array;
+ }
+ 
+ declare var BigUint64Array: BigUint64ArrayConstructor;
+
+```

--- a/docs/diff/es2022.object.d.ts.md
+++ b/docs/diff/es2022.object.d.ts.md
@@ -5,7 +5,7 @@ Index: es2022.object.d.ts
 ===================================================================
 --- es2022.object.d.ts
 +++ es2022.object.d.ts
-@@ -3,6 +3,17 @@
+@@ -3,6 +3,19 @@
     * Determines whether an object has a property with the specified name.
     * @param o An object.
     * @param v A property name.
@@ -21,7 +21,9 @@ Index: es2022.object.d.ts
 +    : symbol extends Key
 +    ? {}
 +    : Key extends PropertyKey
-+    ? { [key in Key]: unknown }
++    ? {
++        [key in Key]: unknown;
++      }
 +    : {};
  }
 

--- a/docs/diff/es5.d.ts.md
+++ b/docs/diff/es5.d.ts.md
@@ -26,7 +26,7 @@ Index: es5.d.ts
    /** The initial value of Object.prototype.constructor is the standard built-in Object constructor. */
    constructor: Function;
  
-@@ -112,14 +111,23 @@
+@@ -112,14 +111,25 @@
    toLocaleString(): string;
  
    /** Returns the primitive value of the specified object. */
@@ -46,13 +46,15 @@ Index: es5.d.ts
 +    : symbol extends Key
 +    ? {}
 +    : Key extends PropertyKey
-+    ? { [key in Key]: unknown }
++    ? {
++        [key in Key]: unknown;
++      }
 +    : {};
  
    /**
     * Determines whether an object exists in another object's prototype chain.
     * @param v Another object whose prototype chain is to be checked.
-@@ -131,22 +139,21 @@
+@@ -131,78 +141,147 @@
     * @param v A property name.
     */
    propertyIsEnumerable(v: PropertyKey): boolean;
@@ -73,18 +75,29 @@ Index: es5.d.ts
     * @param o The object that references the prototype.
     */
 -  getPrototypeOf(o: any): any;
-+  getPrototypeOf(o: any): unknown;
++  getPrototypeOf<T>(o: T): CheckNonNullable<T, unknown>;
  
    /**
     * Gets the own property descriptor of the specified object.
     * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype.
-@@ -162,47 +169,101 @@
+    * @param o Object that contains the property.
+    * @param p Name of the property.
+    */
+-  getOwnPropertyDescriptor(
+-    o: any,
++  getOwnPropertyDescriptor<T>(
++    o: T,
+     p: PropertyKey
+-  ): PropertyDescriptor | undefined;
++  ): CheckNonNullable<T, PropertyDescriptor | undefined>;
+ 
+   /**
     * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
     * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
     * @param o Object that contains the own properties.
     */
 -  getOwnPropertyNames(o: any): string[];
-+  getOwnPropertyNames<O>(o: O): O extends undefined | null ? never : string[];
++  getOwnPropertyNames<T>(o: T): CheckNonNullable<T, string[]>;
  
    /**
     * Creates an object that has the specified prototype or that has null prototype.
@@ -112,9 +125,13 @@ Index: es5.d.ts
 +    o: O,
 +    properties: P & ThisType<any>
 +  ): {
-+    [K in keyof (O & P)]: P[K] extends { value: infer V }
++    [K in keyof (O & P)]: P[K] extends {
++      value: infer V;
++    }
 +      ? V
-+      : P[K] extends { get: () => infer V }
++      : P[K] extends {
++          get: () => infer V;
++        }
 +      ? V
 +      : K extends keyof O
 +      ? O[K]
@@ -130,9 +147,13 @@ Index: es5.d.ts
 +    o: null,
 +    properties: P & ThisType<any>
 +  ): {
-+    [K in keyof P]: P[K] extends { value: infer V }
++    [K in keyof P]: P[K] extends {
++      value: infer V;
++    }
 +      ? V
-+      : P[K] extends { get: () => infer V }
++      : P[K] extends {
++          get: () => infer V;
++        }
 +      ? V
 +      : unknown;
 +  };
@@ -159,9 +180,13 @@ Index: es5.d.ts
 +  ): O &
 +    (P extends PropertyKey // required to make P distributive
 +      ? {
-+          [K in P]: D extends { value: infer V }
++          [K in P]: D extends {
++            value: infer V;
++          }
 +            ? V
-+            : D extends { get: () => infer V }
++            : D extends {
++                get: () => infer V;
++              }
 +            ? V
 +            : unknown;
 +        }
@@ -183,9 +208,13 @@ Index: es5.d.ts
 +    o: O,
 +    properties: P & ThisType<any>
 +  ): {
-+    [K in keyof (O & P)]: P[K] extends { value: infer V }
++    [K in keyof (O & P)]: P[K] extends {
++      value: infer V;
++    }
 +      ? V
-+      : P[K] extends { get: () => infer V }
++      : P[K] extends {
++          get: () => infer V;
++        }
 +      ? V
 +      : K extends keyof O
 +      ? O[K]
@@ -195,7 +224,7 @@ Index: es5.d.ts
    /**
     * Prevents the modification of attributes of existing properties, and prevents the addition of new properties.
     * @param o Object on which to lock the attributes.
-@@ -326,9 +387,8 @@
+@@ -326,9 +405,8 @@
    ? T
    : T extends (...args: infer A) => infer R
    ? (...args: A) => R
@@ -205,7 +234,7 @@ Index: es5.d.ts
    /**
     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
     * @param thisArg The object to be used as the this object.
-@@ -350,56 +410,32 @@
+@@ -350,49 +428,20 @@
      this: (this: T, ...args: A) => R,
      thisArg: T,
      ...args: A
@@ -259,20 +288,14 @@ Index: es5.d.ts
    /**
     * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
     * @param thisArg The object to be used as the this object.
-+   */
-+  apply<T>(this: new () => T, thisArg: T): void;
-+
-+  /**
-+   * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
-+   * @param thisArg The object to be used as the this object.
-    * @param args An array of argument values to be passed to the function.
-    */
--  apply<T>(this: new () => T, thisArg: T): void;
-   apply<T, A extends any[]>(
+@@ -414,55 +463,25 @@
      this: new (...args: A) => T,
      thisArg: T,
-     args: A
-@@ -421,48 +457,19 @@
+     ...args: A
+   ): void;
+-
+   /**
+    * For a given function, creates a bound function that has the same body as the original function.
     * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
     * @param thisArg The object to be used as the this object.
     * @param args Arguments to bind to the parameters of the function.
@@ -326,7 +349,7 @@ Index: es5.d.ts
    /** Returns a string representation of a string. */
    toString(): string;
  
-@@ -508,24 +515,28 @@
+@@ -508,24 +527,28 @@
     * Matches a string with a regular expression, and returns an array containing the results of that search.
     * @param regexp A variable name or string literal containing the regular expression pattern and flags.
     */
@@ -359,7 +382,7 @@ Index: es5.d.ts
  
    /**
     * Finds the first substring match in a regular expression search.
-@@ -1177,9 +1188,8 @@
+@@ -1177,9 +1200,8 @@
    readonly prototype: URIError;
  }
  
@@ -369,7 +392,7 @@ Index: es5.d.ts
    /**
     * Converts a JavaScript Object Notation (JSON) string into an object.
     * @param text A valid JSON string.
-@@ -1187,43 +1197,80 @@
+@@ -1187,43 +1209,80 @@
     * If a member contains nested objects, the nested objects are transformed before the parent object is.
     */
    parse(
@@ -464,7 +487,7 @@ Index: es5.d.ts
    /**
     * Gets the length of the array. This is a number one higher than the highest element defined in an array.
     */
-@@ -1276,11 +1323,16 @@
+@@ -1276,23 +1335,25 @@
     * which is coercible to the Boolean value false, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -472,19 +495,17 @@ Index: es5.d.ts
 -  every<S extends T>(
 -    predicate: (value: T, index: number, array: readonly T[]) => value is S,
 -    thisArg?: any
+-  ): this is readonly S[];
 +  every<S extends T, This = undefined>(
-+    predicate: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => value is S,
++    predicate: (this: This, value: T, index: number, array: this) => value is S,
 +    thisArg?: This
-   ): this is readonly S[];
++  ): this is {
++    [K in keyof this]: S;
++  };
    /**
     * Determines whether all the members of an array satisfy the specified test.
     * @param predicate A function that accepts up to three arguments. The every method calls
-@@ -1288,11 +1340,16 @@
+    * the predicate function for each element in the array until the predicate returns a value
     * which is coercible to the Boolean value false, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -493,18 +514,13 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: readonly T[]) => unknown,
 -    thisArg?: any
 +  every<This = undefined>(
-+    predicate: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): boolean;
    /**
     * Determines whether the specified callback function returns true for any element of an array.
     * @param predicate A function that accepts up to three arguments. The some method calls
-@@ -1300,47 +1357,67 @@
+@@ -1300,117 +1361,99 @@
     * which is coercible to the Boolean value true, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -513,12 +529,7 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: readonly T[]) => unknown,
 -    thisArg?: any
 +  some<This = undefined>(
-+    predicate: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): boolean;
    /**
@@ -530,12 +541,7 @@ Index: es5.d.ts
 -    callbackfn: (value: T, index: number, array: readonly T[]) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => void,
++    callbackfn: (this: This, value: T, index: number, array: this) => void,
 +    thisArg?: This
    ): void;
    /**
@@ -546,10 +552,13 @@ Index: es5.d.ts
 -  map<U>(
 -    callbackfn: (value: T, index: number, array: readonly T[]) => U,
 -    thisArg?: any
+-  ): U[];
 +  map<U, This = undefined>(
-+    callbackfn: (this: This, value: T, index: number, array: readonly T[]) => U,
++    callbackfn: (this: This, value: T, index: number, array: this) => U,
 +    thisArg?: This
-   ): U[];
++  ): {
++    -readonly [K in keyof this]: U;
++  };
    /**
     * Returns the elements of an array that meet the condition specified in a callback function.
     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
@@ -559,12 +568,7 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: readonly T[]) => value is S,
 -    thisArg?: any
 +  filter<S extends T, This = undefined>(
-+    predicate: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => value is S,
++    predicate: (this: This, value: T, index: number, array: this) => value is S,
 +    thisArg?: This
    ): S[];
    /**
@@ -576,18 +580,97 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: readonly T[]) => unknown,
 -    thisArg?: any
 +  filter<This = undefined>(
-+    predicate: (
-+      this: This,
-+      value: T,
-+      index: number,
-+      array: readonly T[]
-+    ) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): T[];
    /**
     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-@@ -1422,9 +1499,8 @@
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduce(
++  reduce<U = T>(
+     callbackfn: (
+-      previousValue: T,
++      previousValue: T | U,
+       currentValue: T,
+       currentIndex: number,
+-      array: readonly T[]
+-    ) => T
+-  ): T;
+-  reduce(
+-    callbackfn: (
+-      previousValue: T,
+-      currentValue: T,
+-      currentIndex: number,
+-      array: readonly T[]
+-    ) => T,
+-    initialValue: T
+-  ): T;
++      array: this
++    ) => U
++  ): T | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = T>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: T,
+       currentIndex: number,
+-      array: readonly T[]
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = T>(
+     callbackfn: (
+-      previousValue: T,
++      previousValue: T | U,
+       currentValue: T,
+       currentIndex: number,
+-      array: readonly T[]
+-    ) => T
+-  ): T;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: T,
+-      currentValue: T,
+-      currentIndex: number,
+-      array: readonly T[]
+-    ) => T,
+-    initialValue: T
+-  ): T;
++      array: this
++    ) => U
++  ): T | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = T>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: T,
+       currentIndex: number,
+-      array: readonly T[]
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -1422,9 +1465,8 @@
    readonly [n: number]: T;
    join(separator?: string): string;
    slice(start?: number, end?: number): T[];
@@ -597,27 +680,7 @@ Index: es5.d.ts
    /**
     * Gets or sets the length of the array. This is a number one higher than the highest index in the array.
     */
-@@ -1500,17 +1576,17 @@
-    * @param start The zero-based location in the array from which to start removing elements.
-    * @param deleteCount The number of elements to remove.
-    * @returns An array containing the elements that were deleted.
-    */
--  splice(start: number, deleteCount?: number): T[];
-+  splice(start: number, deleteCount?: number): this;
-   /**
-    * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-    * @param start The zero-based location in the array from which to start removing elements.
-    * @param deleteCount The number of elements to remove.
-    * @param items Elements to insert into the array in place of the deleted elements.
-    * @returns An array containing the elements that were deleted.
-    */
--  splice(start: number, deleteCount: number, ...items: T[]): T[];
-+  splice(start: number, deleteCount: number, ...items: T[]): this;
-   /**
-    * Inserts new elements at the start of an array, and returns the new length of the array.
-    * @param items Elements to insert at the start of the array.
-    */
-@@ -1534,11 +1610,11 @@
+@@ -1534,23 +1576,25 @@
     * which is coercible to the Boolean value false, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -625,14 +688,17 @@ Index: es5.d.ts
 -  every<S extends T>(
 -    predicate: (value: T, index: number, array: T[]) => value is S,
 -    thisArg?: any
+-  ): this is S[];
 +  every<S extends T, This = undefined>(
-+    predicate: (this: This, value: T, index: number, array: T[]) => value is S,
++    predicate: (this: This, value: T, index: number, array: this) => value is S,
 +    thisArg?: This
-   ): this is S[];
++  ): this is {
++    [K in keyof this]: S;
++  };
    /**
     * Determines whether all the members of an array satisfy the specified test.
     * @param predicate A function that accepts up to three arguments. The every method calls
-@@ -1546,11 +1622,11 @@
+    * the predicate function for each element in the array until the predicate returns a value
     * which is coercible to the Boolean value false, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -641,13 +707,13 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: T[]) => unknown,
 -    thisArg?: any
 +  every<This = undefined>(
-+    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): boolean;
    /**
     * Determines whether the specified callback function returns true for any element of an array.
     * @param predicate A function that accepts up to three arguments. The some method calls
-@@ -1558,47 +1634,47 @@
+@@ -1558,133 +1602,112 @@
     * which is coercible to the Boolean value true, or until the end of the array.
     * @param thisArg An object to which the this keyword can refer in the predicate function.
     * If thisArg is omitted, undefined is used as the this value.
@@ -656,7 +722,7 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: T[]) => unknown,
 -    thisArg?: any
 +  some<This = undefined>(
-+    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): boolean;
    /**
@@ -668,7 +734,7 @@ Index: es5.d.ts
 -    callbackfn: (value: T, index: number, array: T[]) => void,
 -    thisArg?: any
 +  forEach<This = undefined>(
-+    callbackfn: (this: This, value: T, index: number, array: T[]) => void,
++    callbackfn: (this: This, value: T, index: number, array: this) => void,
 +    thisArg?: This
    ): void;
    /**
@@ -679,10 +745,13 @@ Index: es5.d.ts
 -  map<U>(
 -    callbackfn: (value: T, index: number, array: T[]) => U,
 -    thisArg?: any
+-  ): U[];
 +  map<U, This = undefined>(
-+    callbackfn: (this: This, value: T, index: number, array: T[]) => U,
++    callbackfn: (this: This, value: T, index: number, array: this) => U,
 +    thisArg?: This
-   ): U[];
++  ): {
++    [K in keyof this]: U;
++  };
    /**
     * Returns the elements of an array that meet the condition specified in a callback function.
     * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
@@ -692,7 +761,7 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: T[]) => value is S,
 -    thisArg?: any
 +  filter<S extends T, This = undefined>(
-+    predicate: (this: This, value: T, index: number, array: T[]) => value is S,
++    predicate: (this: This, value: T, index: number, array: this) => value is S,
 +    thisArg?: This
    ): S[];
    /**
@@ -704,13 +773,94 @@ Index: es5.d.ts
 -    predicate: (value: T, index: number, array: T[]) => unknown,
 -    thisArg?: any
 +  filter<This = undefined>(
-+    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
++    predicate: (this: This, value: T, index: number, array: this) => boolean,
 +    thisArg?: This
    ): T[];
    /**
     * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
     * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-@@ -1673,18 +1749,15 @@
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduce(
++  reduce<U = T>(
+     callbackfn: (
+-      previousValue: T,
++      previousValue: T | U,
+       currentValue: T,
+       currentIndex: number,
+-      array: T[]
+-    ) => T
+-  ): T;
+-  reduce(
+-    callbackfn: (
+-      previousValue: T,
+-      currentValue: T,
+-      currentIndex: number,
+-      array: T[]
+-    ) => T,
+-    initialValue: T
+-  ): T;
++      array: this
++    ) => U
++  ): T | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = T>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: T,
+       currentIndex: number,
+-      array: T[]
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = T>(
+     callbackfn: (
+-      previousValue: T,
++      previousValue: T | U,
+       currentValue: T,
+       currentIndex: number,
+-      array: T[]
+-    ) => T
+-  ): T;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: T,
+-      currentValue: T,
+-      currentIndex: number,
+-      array: T[]
+-    ) => T,
+-    initialValue: T
+-  ): T;
++      array: this
++    ) => U
++  ): T | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = T>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: T,
+       currentIndex: number,
+-      array: T[]
++      array: this
+     ) => U,
+     initialValue: U
    ): U;
  
    [n: number]: T;
@@ -731,7 +881,7 @@ Index: es5.d.ts
  
  declare var Array: ArrayConstructor;
  
-@@ -1716,9 +1789,15 @@
+@@ -1716,9 +1739,15 @@
  ) => void;
  
  declare type PromiseConstructorLike = new <T>(
@@ -748,7 +898,2905 @@ Index: es5.d.ts
    ) => void
  ) => PromiseLike<T>;
  
-@@ -5434,9 +5513,8 @@
+@@ -2087,13 +2116,8 @@
+     byteLength?: number
+   ): DataView;
+ }
+ declare var DataView: DataViewConstructor;
+-
+-/**
+- * A typed array of 8-bit integer values. The contents are initialized to 0. If the requested
+- * number of bytes could not be allocated an exception is raised.
+- */
+ interface Int8Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -2123,20 +2147,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Int8Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -2146,21 +2174,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Int8Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Int8Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2168,13 +2199,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Int8Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2182,23 +2212,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Int8Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Int8Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -2226,50 +2255,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Int8Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Int8Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int8Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int8Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -2278,46 +2297,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int8Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int8Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int8Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -2326,14 +2331,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int8Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -2354,20 +2359,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Int8Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Int8Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -2422,33 +2431,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Int8Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Int8Array;
+-
++  from(source: ArrayLike<number>): Int8Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int8Array;
+ }
+ declare var Int8Array: Int8ArrayConstructor;
+-
+-/**
+- * A typed array of 8-bit unsigned integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Uint8Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -2478,20 +2480,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Uint8Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -2501,21 +2507,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Uint8Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Uint8Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2523,13 +2532,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Uint8Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2537,23 +2545,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Uint8Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Uint8Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -2581,50 +2588,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Uint8Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Uint8Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint8Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -2633,46 +2630,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint8Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -2681,14 +2664,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -2709,20 +2692,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Uint8Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Uint8Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -2757,9 +2744,8 @@
+   valueOf(): Uint8Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Uint8ArrayConstructor {
+   readonly prototype: Uint8Array;
+   new (length: number): Uint8Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Uint8Array;
+@@ -2778,33 +2764,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Uint8Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Uint8Array;
+-
++  from(source: ArrayLike<number>): Uint8Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint8Array;
+ }
+ declare var Uint8Array: Uint8ArrayConstructor;
+-
+-/**
+- * A typed array of 8-bit unsigned integer (clamped) values. The contents are initialized to 0.
+- * If the requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Uint8ClampedArray {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -2834,24 +2813,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
++  every<This = undefined>(
+     predicate: (
++      this: This,
+       value: number,
+       index: number,
+-      array: Uint8ClampedArray
+-    ) => unknown,
+-    thisArg?: any
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -2861,21 +2840,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Uint8ClampedArray) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Uint8ClampedArray;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2883,17 +2865,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (
+-      value: number,
+-      index: number,
+-      obj: Uint8ClampedArray
+-    ) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -2901,31 +2878,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (
+-      value: number,
+-      index: number,
+-      obj: Uint8ClampedArray
+-    ) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (
+-      value: number,
+-      index: number,
+-      array: Uint8ClampedArray
+-    ) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -2953,54 +2921,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
++  map<This = undefined>(
+     callbackfn: (
++      this: This,
+       value: number,
+       index: number,
+-      array: Uint8ClampedArray
++      array: this
+     ) => number,
+-    thisArg?: any
++    thisArg?: This
+   ): Uint8ClampedArray;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8ClampedArray
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint8ClampedArray
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -3009,46 +2963,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8ClampedArray
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8ClampedArray
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint8ClampedArray
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -3057,14 +2997,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint8ClampedArray
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -3085,24 +3025,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Uint8ClampedArray;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
++  some<This = undefined>(
+     predicate: (
++      this: This,
+       value: number,
+       index: number,
+-      array: Uint8ClampedArray
+-    ) => unknown,
+-    thisArg?: any
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -3137,9 +3077,8 @@
+   valueOf(): Uint8ClampedArray;
+ 
+   [index: number]: number;
+ }
+-
+ interface Uint8ClampedArrayConstructor {
+   readonly prototype: Uint8ClampedArray;
+   new (length: number): Uint8ClampedArray;
+   new (array: ArrayLike<number> | ArrayBufferLike): Uint8ClampedArray;
+@@ -3158,33 +3097,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Uint8ClampedArray;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Uint8ClampedArray;
+-
++  from(source: ArrayLike<number>): Uint8ClampedArray;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint8ClampedArray;
+ }
+ declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
+-
+-/**
+- * A typed array of 16-bit signed integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Int16Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -3214,20 +3146,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Int16Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -3237,21 +3173,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Int16Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Int16Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3259,13 +3198,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Int16Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3273,23 +3211,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Int16Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Int16Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+    * @param searchElement The value to locate in the array.
+@@ -3316,50 +3253,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Int16Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Int16Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int16Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int16Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -3368,46 +3295,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int16Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int16Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int16Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -3416,14 +3329,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int16Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -3444,20 +3357,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Int16Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Int16Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -3492,9 +3409,8 @@
+   valueOf(): Int16Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Int16ArrayConstructor {
+   readonly prototype: Int16Array;
+   new (length: number): Int16Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Int16Array;
+@@ -3513,33 +3429,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Int16Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Int16Array;
+-
++  from(source: ArrayLike<number>): Int16Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int16Array;
+ }
+ declare var Int16Array: Int16ArrayConstructor;
+-
+-/**
+- * A typed array of 16-bit unsigned integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Uint16Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -3569,20 +3478,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Uint16Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -3592,21 +3505,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Uint16Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Uint16Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3614,13 +3530,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Uint16Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3628,23 +3543,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Uint16Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Uint16Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -3672,50 +3586,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Uint16Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Uint16Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint16Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint16Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -3724,46 +3628,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint16Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint16Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint16Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -3772,14 +3662,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint16Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -3800,20 +3690,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Uint16Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Uint16Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -3848,9 +3742,8 @@
+   valueOf(): Uint16Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Uint16ArrayConstructor {
+   readonly prototype: Uint16Array;
+   new (length: number): Uint16Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Uint16Array;
+@@ -3869,32 +3762,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Uint16Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Uint16Array;
+-
++  from(source: ArrayLike<number>): Uint16Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint16Array;
+ }
+ declare var Uint16Array: Uint16ArrayConstructor;
+-/**
+- * A typed array of 32-bit signed integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Int32Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -3924,20 +3811,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Int32Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -3947,21 +3838,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Int32Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Int32Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3969,13 +3863,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Int32Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -3983,23 +3876,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Int32Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Int32Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -4027,50 +3919,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Int32Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Int32Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int32Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -4079,46 +3961,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int32Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Int32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -4127,14 +3995,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Int32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -4155,20 +4023,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Int32Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Int32Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -4203,9 +4075,8 @@
+   valueOf(): Int32Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Int32ArrayConstructor {
+   readonly prototype: Int32Array;
+   new (length: number): Int32Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Int32Array;
+@@ -4224,33 +4095,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Int32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Int32Array;
+-
++  from(source: ArrayLike<number>): Int32Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Int32Array;
+ }
+ declare var Int32Array: Int32ArrayConstructor;
+-
+-/**
+- * A typed array of 32-bit unsigned integer values. The contents are initialized to 0. If the
+- * requested number of bytes could not be allocated an exception is raised.
+- */
+ interface Uint32Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -4280,20 +4144,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Uint32Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -4303,21 +4171,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Uint32Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Uint32Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -4325,13 +4196,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Uint32Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -4339,23 +4209,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Uint32Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Uint32Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+    * @param searchElement The value to locate in the array.
+@@ -4382,50 +4251,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Uint32Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Uint32Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint32Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -4434,46 +4293,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint32Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Uint32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -4482,14 +4327,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Uint32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -4510,20 +4355,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Uint32Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Uint32Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -4558,9 +4407,8 @@
+   valueOf(): Uint32Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Uint32ArrayConstructor {
+   readonly prototype: Uint32Array;
+   new (length: number): Uint32Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Uint32Array;
+@@ -4579,33 +4427,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Uint32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Uint32Array;
+-
++  from(source: ArrayLike<number>): Uint32Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Uint32Array;
+ }
+ declare var Uint32Array: Uint32ArrayConstructor;
+-
+-/**
+- * A typed array of 32-bit float values. The contents are initialized to 0. If the requested number
+- * of bytes could not be allocated an exception is raised.
+- */
+ interface Float32Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -4635,20 +4476,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Float32Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -4658,21 +4503,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Float32Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Float32Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -4680,13 +4528,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Float32Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -4694,23 +4541,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Float32Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Float32Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -4738,50 +4584,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Float32Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Float32Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float32Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Float32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -4790,46 +4626,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float32Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Float32Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -4838,14 +4660,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float32Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -4866,20 +4688,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Float32Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Float32Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -4914,9 +4740,8 @@
+   valueOf(): Float32Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Float32ArrayConstructor {
+   readonly prototype: Float32Array;
+   new (length: number): Float32Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Float32Array;
+@@ -4935,33 +4760,26 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Float32Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Float32Array;
+-
++  from(source: ArrayLike<number>): Float32Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Float32Array;
+ }
+ declare var Float32Array: Float32ArrayConstructor;
+-
+-/**
+- * A typed array of 64-bit float values. The contents are initialized to 0. If the requested
+- * number of bytes could not be allocated an exception is raised.
+- */
+ interface Float64Array {
+   /**
+    * The size in bytes of each element in the array.
+    */
+@@ -4991,20 +4809,24 @@
+    * is treated as length+end.
+    * @param end If not specified, length of the this object is used as its default value.
+    */
+   copyWithin(target: number, start: number, end?: number): this;
+-
+   /**
+    * Determines whether all the members of an array satisfy the specified test.
+    * @param predicate A function that accepts up to three arguments. The every method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value false, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  every(
+-    predicate: (value: number, index: number, array: Float64Array) => unknown,
+-    thisArg?: any
++  every<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Changes all array elements from `start` to `end` index to a static `value` and returns the modified array
+@@ -5014,21 +4836,24 @@
+    * @param end index to stop filling the array at. If end is negative, it is treated as
+    * length+end.
+    */
+   fill(value: number, start?: number, end?: number): this;
+-
+   /**
+    * Returns the elements of an array that meet the condition specified in a callback function.
+    * @param predicate A function that accepts up to three arguments. The filter method calls
+    * the predicate function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  filter(
+-    predicate: (value: number, index: number, array: Float64Array) => any,
+-    thisArg?: any
++  filter<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): Float64Array;
+-
+   /**
+    * Returns the value of the first element in the array where predicate is true, and undefined
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -5036,13 +4861,12 @@
+    * immediately returns that element value. Otherwise, find returns undefined.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  find(
+-    predicate: (value: number, index: number, obj: Float64Array) => boolean,
+-    thisArg?: any
++  find<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number | undefined;
+-
+   /**
+    * Returns the index of the first element in the array where predicate is true, and -1
+    * otherwise.
+    * @param predicate find calls predicate once for each element of the array, in ascending
+@@ -5050,23 +4874,22 @@
+    * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+    * @param thisArg If provided, it will be used as the this value for each invocation of
+    * predicate. If it is not provided, undefined is used instead.
+    */
+-  findIndex(
+-    predicate: (value: number, index: number, obj: Float64Array) => boolean,
+-    thisArg?: any
++  findIndex<This = undefined>(
++    predicate: (this: This, value: number, index: number, obj: this) => boolean,
++    thisArg?: This
+   ): number;
+-
+   /**
+    * Performs the specified action for each element in an array.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  forEach(
+-    callbackfn: (value: number, index: number, array: Float64Array) => void,
+-    thisArg?: any
++  forEach<This = undefined>(
++    callbackfn: (this: This, value: number, index: number, array: this) => void,
++    thisArg?: This
+   ): void;
+ 
+   /**
+    * Returns the index of the first occurrence of a value in an array.
+@@ -5094,50 +4917,40 @@
+   /**
+    * The length of the array.
+    */
+   readonly length: number;
+-
+   /**
+    * Calls a defined callback function on each element of an array, and returns an array that
+    * contains the results.
+    * @param callbackfn A function that accepts up to three arguments. The map method calls the
+    * callbackfn function one time for each element in the array.
+    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  map(
+-    callbackfn: (value: number, index: number, array: Float64Array) => number,
+-    thisArg?: any
++  map<This = undefined>(
++    callbackfn: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => number,
++    thisArg?: This
+   ): Float64Array;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+    * callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an argument
+-   * instead of an array value.
+    */
+-  reduce(
++  reduce<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float64Array
+-    ) => number
+-  ): number;
+-  reduce(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Float64Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array. The return value of
+    * the callback function is the accumulated result, and is provided as an argument in the next
+    * call to the callback function.
+@@ -5146,46 +4959,32 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduce<U>(
++  reduce<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+-
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+    * the callbackfn function one time for each element in the array.
+-   * @param initialValue If initialValue is specified, it is used as the initial value to start
+-   * the accumulation. The first call to the callbackfn function provides this value as an
+-   * argument instead of an array value.
+    */
+-  reduceRight(
++  reduceRight<U = number>(
+     callbackfn: (
+-      previousValue: number,
++      previousValue: number | U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float64Array
+-    ) => number
+-  ): number;
+-  reduceRight(
+-    callbackfn: (
+-      previousValue: number,
+-      currentValue: number,
+-      currentIndex: number,
+-      array: Float64Array
+-    ) => number,
+-    initialValue: number
+-  ): number;
+-
++      array: this
++    ) => U
++  ): number | U;
+   /**
+    * Calls the specified callback function for all the elements in an array, in descending order.
+    * The return value of the callback function is the accumulated result, and is provided as an
+    * argument in the next call to the callback function.
+@@ -5194,14 +4993,14 @@
+    * @param initialValue If initialValue is specified, it is used as the initial value to start
+    * the accumulation. The first call to the callbackfn function provides this value as an argument
+    * instead of an array value.
+    */
+-  reduceRight<U>(
++  reduceRight<U = number>(
+     callbackfn: (
+       previousValue: U,
+       currentValue: number,
+       currentIndex: number,
+-      array: Float64Array
++      array: this
+     ) => U,
+     initialValue: U
+   ): U;
+ 
+@@ -5222,20 +5021,24 @@
+    * @param start The beginning of the specified portion of the array.
+    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
+    */
+   slice(start?: number, end?: number): Float64Array;
+-
+   /**
+    * Determines whether the specified callback function returns true for any element of an array.
+    * @param predicate A function that accepts up to three arguments. The some method calls
+    * the predicate function for each element in the array until the predicate returns a value
+    * which is coercible to the Boolean value true, or until the end of the array.
+    * @param thisArg An object to which the this keyword can refer in the predicate function.
+    * If thisArg is omitted, undefined is used as the this value.
+    */
+-  some(
+-    predicate: (value: number, index: number, array: Float64Array) => unknown,
+-    thisArg?: any
++  some<This = undefined>(
++    predicate: (
++      this: This,
++      value: number,
++      index: number,
++      array: this
++    ) => boolean,
++    thisArg?: This
+   ): boolean;
+ 
+   /**
+    * Sorts an array.
+@@ -5261,9 +5064,8 @@
+   valueOf(): Float64Array;
+ 
+   [index: number]: number;
+ }
+-
+ interface Float64ArrayConstructor {
+   readonly prototype: Float64Array;
+   new (length: number): Float64Array;
+   new (array: ArrayLike<number> | ArrayBufferLike): Float64Array;
+@@ -5282,25 +5084,23 @@
+    * Returns a new array from a set of elements.
+    * @param items A set of elements to include in the new array object.
+    */
+   of(...items: number[]): Float64Array;
+-
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    */
+-  from(arrayLike: ArrayLike<number>): Float64Array;
+-
++  from(source: ArrayLike<number>): Float64Array;
+   /**
+    * Creates an array from an array-like or iterable object.
+-   * @param arrayLike An array-like or iterable object to convert to an array.
++   * @param source An array-like or iterable object to convert to an array.
+    * @param mapfn A mapping function to call on every element of the array.
+    * @param thisArg Value of 'this' used to invoke the mapfn.
+    */
+-  from<T>(
+-    arrayLike: ArrayLike<T>,
+-    mapfn: (v: T, k: number) => number,
+-    thisArg?: any
++  from<T, This = undefined>(
++    source: ArrayLike<T>,
++    mapfn: (this: This, v: T, k: number) => number,
++    thisArg?: This
+   ): Float64Array;
+ }
+ declare var Float64Array: Float64ArrayConstructor;
+ 
+@@ -5434,9 +5234,8 @@
        options?: DateTimeFormatOptions
      ): string[];
    };
@@ -758,7 +3806,7 @@ Index: es5.d.ts
    /**
     * Determines whether two strings are equivalent in the current or specified locale.
     * @param that String to compare to target string
-@@ -5491,4 +5569,22 @@
+@@ -5491,4 +5290,24 @@
      locales?: string | string[],
      options?: Intl.DateTimeFormatOptions
    ): string;
@@ -771,6 +3819,8 @@ Index: es5.d.ts
 +) extends (arg: infer F) => void
 +  ? F
 +  : unknown;
++
++type CheckNonNullable<T, U> = [T] extends [NonNullable<T>] ? U : never;
 +
 +type JSONValue =
 +  | null

--- a/generated/lib.es2015.collection.d.ts
+++ b/generated/lib.es2015.collection.d.ts
@@ -2,7 +2,7 @@ interface Map<K, V> {
   clear(): void;
   delete(key: K): boolean;
   forEach<This = undefined>(
-    callbackfn: (this: This, value: V, key: K, map: Map<K, V>) => void,
+    callbackfn: (this: This, value: V, key: K, map: this) => void,
     thisArg?: This
   ): void;
   get(key: K): V | undefined;
@@ -23,7 +23,7 @@ interface MapConstructor {
 declare var Map: MapConstructor;
 interface ReadonlyMap<K, V> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    callbackfn: (this: This, value: V, key: K, map: this) => void,
     thisArg?: This
   ): void;
   get(key: K): V | undefined;
@@ -53,7 +53,7 @@ interface Set<T> {
   clear(): void;
   delete(value: T): boolean;
   forEach<This = undefined>(
-    callbackfn: (this: This, value: T, value2: T, set: Set<T>) => void,
+    callbackfn: (this: This, value: T, value2: T, set: this) => void,
     thisArg?: This
   ): void;
   has(value: T): boolean;
@@ -71,7 +71,7 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 interface ReadonlySet<T> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: T, value2: T, set: ReadonlySet<T>) => void,
+    callbackfn: (this: This, value: T, value2: T, set: this) => void,
     thisArg?: This
   ): void;
   has(value: T): boolean;

--- a/generated/lib.es2015.core.d.ts
+++ b/generated/lib.es2015.core.d.ts
@@ -8,13 +8,23 @@ interface Array<T> {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find<S extends T>(
-    predicate: (this: void, value: T, index: number, obj: T[]) => value is S,
-    thisArg?: any
+  find<S extends T, This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => value is S,
+    thisArg?: This
   ): S | undefined;
-  find(
-    predicate: (value: T, index: number, obj: T[]) => unknown,
-    thisArg?: any
+
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
   ): T | undefined;
 
   /**
@@ -26,9 +36,9 @@ interface Array<T> {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: T, index: number, obj: T[]) => unknown,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
 
   /**
@@ -52,24 +62,45 @@ interface Array<T> {
    */
   copyWithin(target: number, start: number, end?: number): this;
 }
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find<S extends T>(predicate: (this: void, value: T, index: number, obj: T[]) => value is S, thisArg?: any): S | undefined;
+//     find(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): T | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: T, index: number, obj: T[]) => unknown, thisArg?: any): number;
 
 interface ArrayConstructor {
   /**
-   * Creates an array from an array-like object.
-   * @param arrayLike An array-like object to convert to an array.
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from<T>(arrayLike: ArrayLike<T>): T[];
+  from<T>(source: ArrayLike<T>): T[];
 
   /**
-   * Creates an array from an iterable object.
-   * @param arrayLike An array-like object to convert to an array.
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T, U>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => U,
-    thisArg?: any
+  from<T, U, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => U,
+    thisArg?: This
   ): U[];
 
   /**
@@ -78,6 +109,18 @@ interface ArrayConstructor {
    */
   of<T>(...items: T[]): T[];
 }
+//     /**
+//      * Creates an array from an array-like object.
+//      * @param arrayLike An array-like object to convert to an array.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>): T[];
+//     /**
+//      * Creates an array from an iterable object.
+//      * @param arrayLike An array-like object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T, U>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
 
 interface DateConstructor {
   new (value: number | string | Date): Date;
@@ -301,7 +344,17 @@ interface ObjectConstructor {
   assign<T, Ts extends readonly any[]>(
     target: T,
     ...sources: Ts
-  ): First<UnionToIntersection<[T] | { [K in keyof Ts]: [Ts[K]] }[number]>>;
+  ): CheckNonNullable<
+    T,
+    First<
+      UnionToIntersection<
+        | [T]
+        | {
+            [K in keyof Ts]: [Ts[K]];
+          }[number]
+      >
+    >
+  >;
 
   /**
    * Returns an array of all symbol properties found directly on object o.
@@ -390,18 +443,23 @@ interface ReadonlyArray<T> {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find<S extends T>(
-    predicate: (
-      this: void,
-      value: T,
-      index: number,
-      obj: readonly T[]
-    ) => value is S,
-    thisArg?: any
+  find<S extends T, This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => value is S,
+    thisArg?: This
   ): S | undefined;
-  find(
-    predicate: (value: T, index: number, obj: readonly T[]) => unknown,
-    thisArg?: any
+
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
   ): T | undefined;
 
   /**
@@ -413,11 +471,32 @@ interface ReadonlyArray<T> {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: T, index: number, obj: readonly T[]) => unknown,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
 }
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find<S extends T>(predicate: (this: void, value: T, index: number, obj: readonly T[]) => value is S, thisArg?: any): S | undefined;
+//     find(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): T | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: T, index: number, obj: readonly T[]) => unknown, thisArg?: any): number;
 
 interface RegExp {
   /**

--- a/generated/lib.es2015.iterable.d.ts
+++ b/generated/lib.es2015.iterable.d.ts
@@ -64,26 +64,37 @@ interface Array<T> {
    */
   values(): IterableIterator<T>;
 }
-
 interface ArrayConstructor {
   /**
-   * Creates an array from an iterable object.
-   * @param iterable An iterable object to convert to an array.
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from<T>(iterable: Iterable<T> | ArrayLike<T>): T[];
+  from<T>(source: Iterable<T> | ArrayLike<T>): T[];
 
   /**
-   * Creates an array from an iterable object.
-   * @param iterable An iterable object to convert to an array.
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T, U>(
-    iterable: Iterable<T> | ArrayLike<T>,
-    mapfn: (v: T, k: number) => U,
-    thisArg?: any
+  from<T, U, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => U,
+    thisArg?: This
   ): U[];
 }
+//     /**
+//      * Creates an array from an iterable object.
+//      * @param iterable An iterable object to convert to an array.
+//      */
+//     from<T>(iterable: Iterable<T> | ArrayLike<T>): T[];
+//     /**
+//      * Creates an array from an iterable object.
+//      * @param iterable An iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T, U>(iterable: Iterable<T> | ArrayLike<T>, mapfn: (v: T, k: number) => U, thisArg?: any): U[];
 
 interface ReadonlyArray<T> {
   /** Iterator of values in the array. */
@@ -263,22 +274,32 @@ interface Int8Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Int8ArrayConstructor {
   new (elements: Iterable<number>): Int8Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Int8Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int8Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int8Array;
 
 interface Uint8Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -295,22 +316,32 @@ interface Uint8Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Uint8ArrayConstructor {
   new (elements: Iterable<number>): Uint8Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Uint8Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint8Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint8Array;
 
 interface Uint8ClampedArray {
   [Symbol.iterator](): IterableIterator<number>;
@@ -329,22 +360,32 @@ interface Uint8ClampedArray {
    */
   values(): IterableIterator<number>;
 }
-
 interface Uint8ClampedArrayConstructor {
   new (elements: Iterable<number>): Uint8ClampedArray;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Uint8ClampedArray;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint8ClampedArray;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint8ClampedArray;
 
 interface Int16Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -363,22 +404,32 @@ interface Int16Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Int16ArrayConstructor {
   new (elements: Iterable<number>): Int16Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Int16Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int16Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int16Array;
 
 interface Uint16Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -395,22 +446,32 @@ interface Uint16Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Uint16ArrayConstructor {
   new (elements: Iterable<number>): Uint16Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Uint16Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint16Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint16Array;
 
 interface Int32Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -427,22 +488,32 @@ interface Int32Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Int32ArrayConstructor {
   new (elements: Iterable<number>): Int32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Int32Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int32Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Int32Array;
 
 interface Uint32Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -459,22 +530,32 @@ interface Uint32Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Uint32ArrayConstructor {
   new (elements: Iterable<number>): Uint32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Uint32Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint32Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Uint32Array;
 
 interface Float32Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -491,22 +572,32 @@ interface Float32Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Float32ArrayConstructor {
   new (elements: Iterable<number>): Float32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Float32Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Float32Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Float32Array;
 
 interface Float64Array {
   [Symbol.iterator](): IterableIterator<number>;
@@ -523,19 +614,29 @@ interface Float64Array {
    */
   values(): IterableIterator<number>;
 }
-
 interface Float64ArrayConstructor {
   new (elements: Iterable<number>): Float64Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): Float64Array;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(
-    arrayLike: Iterable<number>,
-    mapfn?: (v: number, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Float64Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: Iterable<number>, mapfn?: (v: number, k: number) => number, thisArg?: any): Float64Array;

--- a/generated/lib.es2015.symbol.wellknown.d.ts
+++ b/generated/lib.es2015.symbol.wellknown.d.ts
@@ -75,7 +75,9 @@ interface Array<T> {
    * Returns an object whose properties have the value 'true'
    * when they will be absent when used in a 'with' statement.
    */
-  readonly [Symbol.unscopables]: { [key: PropertyKey]: boolean };
+  readonly [Symbol.unscopables]: {
+    [key: PropertyKey]: boolean;
+  };
 }
 //     /**
 //      * Returns an object whose properties have the value 'true'

--- a/generated/lib.es2017.object.d.ts
+++ b/generated/lib.es2017.object.d.ts
@@ -13,7 +13,7 @@ interface ObjectConstructor {
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  values(o: unknown): unknown[];
+  values<T>(o: T): CheckNonNullable<T, unknown[]>;
 
   /**
    * Returns an array of key/values of the enumerable properties of an object
@@ -29,17 +29,20 @@ interface ObjectConstructor {
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<T>(o: T): [string, unknown][];
+  entries<T>(o: T): CheckNonNullable<T, [string, unknown][]>;
 
   /**
    * Returns an object containing all own property descriptors of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  getOwnPropertyDescriptors<T>(
-    o: T
-  ): { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & {
-    [x: string]: PropertyDescriptor;
-  };
+  getOwnPropertyDescriptors<T>(o: T): CheckNonNullable<
+    T,
+    {
+      [P in keyof T]: TypedPropertyDescriptor<T[P]>;
+    } & {
+      [x: string]: PropertyDescriptor;
+    }
+  >;
 }
 //     /**
 //      * Returns an array of values of the enumerable properties of an object
@@ -61,3 +64,8 @@ interface ObjectConstructor {
 //      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
 //      */
 //     entries(o: {}): [string, any][];
+//     /**
+//      * Returns an object containing all own property descriptors of an object
+//      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+//      */
+//     getOwnPropertyDescriptors<T>(o: T): {[P in keyof T]: TypedPropertyDescriptor<T[P]>} & { [x: string]: PropertyDescriptor };

--- a/generated/lib.es2020.bigint.d.ts
+++ b/generated/lib.es2020.bigint.d.ts
@@ -229,11 +229,6 @@ interface BigIntConstructor {
 }
 
 declare var BigInt: BigIntConstructor;
-
-/**
- * A typed array of 64-bit signed integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated, an exception is raised.
- */
 interface BigInt64Array {
   /** The size in bytes of each element in the array. */
   readonly BYTES_PER_ELEMENT: number;
@@ -260,7 +255,6 @@ interface BigInt64Array {
 
   /** Yields index, value pairs for every entry in the array. */
   entries(): IterableIterator<[number, bigint]>;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -269,9 +263,14 @@ interface BigInt64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -283,7 +282,6 @@ interface BigInt64Array {
    * length+end.
    */
   fill(value: bigint, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -291,11 +289,15 @@ interface BigInt64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: bigint, index: number, array: BigInt64Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): BigInt64Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -305,11 +307,15 @@ interface BigInt64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): bigint | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -319,11 +325,15 @@ interface BigInt64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -331,9 +341,9 @@ interface BigInt64Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: bigint, index: number, array: BigInt64Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: bigint, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -371,7 +381,6 @@ interface BigInt64Array {
 
   /** The length of the array. */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -380,30 +389,30 @@ interface BigInt64Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: bigint, index: number, array: BigInt64Array) => bigint,
-    thisArg?: any
+  map<This = undefined>(
+    callbackfn: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => bigint,
+    thisArg?: This
   ): BigInt64Array;
-
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
    * call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
    * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
    */
-  reduce(
+  reduce<U = bigint>(
     callbackfn: (
-      previousValue: bigint,
+      previousValue: bigint | U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigInt64Array
-    ) => bigint
-  ): bigint;
-
+      array: this
+    ) => U
+  ): bigint | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -414,35 +423,30 @@ interface BigInt64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = bigint>(
     callbackfn: (
       previousValue: U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigInt64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = bigint>(
     callbackfn: (
-      previousValue: bigint,
+      previousValue: bigint | U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigInt64Array
-    ) => bigint
-  ): bigint;
-
+      array: this
+    ) => U
+  ): bigint | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -453,12 +457,12 @@ interface BigInt64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = bigint>(
     callbackfn: (
       previousValue: U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigInt64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -479,7 +483,6 @@ interface BigInt64Array {
    * @param end The end of the specified portion of the array.
    */
   slice(start?: number, end?: number): BigInt64Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls the
@@ -488,9 +491,14 @@ interface BigInt64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: bigint, index: number, array: BigInt64Array) => boolean,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -525,6 +533,113 @@ interface BigInt64Array {
 
   [index: number]: bigint;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns false,
+//      * or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: bigint, index: number, array: BigInt64Array) => any, thisArg?: any): BigInt64Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): bigint | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: bigint, index: number, array: BigInt64Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: bigint, index: number, array: BigInt64Array) => bigint, thisArg?: any): BigInt64Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigInt64Array) => bigint): bigint;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigInt64Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigInt64Array) => bigint): bigint;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigInt64Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls the
+//      * predicate function for each element in the array until the predicate returns true, or until
+//      * the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: bigint, index: number, array: BigInt64Array) => boolean, thisArg?: any): boolean;
 
 interface BigInt64ArrayConstructor {
   readonly prototype: BigInt64Array;
@@ -544,27 +659,33 @@ interface BigInt64ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: bigint[]): BigInt64Array;
-
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param arrayLike An array-like or iterable object to convert to an array.
+   */
+  from(arrayLike: Iterable<bigint> | ArrayLike<bigint>): BigInt64Array;
   /**
    * Creates an array from an array-like or iterable object.
    * @param arrayLike An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(arrayLike: ArrayLike<bigint>): BigInt64Array;
-  from<U>(
-    arrayLike: ArrayLike<U>,
-    mapfn: (v: U, k: number) => bigint,
-    thisArg?: any
+  from<T, This = undefined>(
+    arrayLike: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => bigint,
+    thisArg?: This
   ): BigInt64Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: ArrayLike<bigint>): BigInt64Array;
+//     from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigInt64Array;
 
 declare var BigInt64Array: BigInt64ArrayConstructor;
-
-/**
- * A typed array of 64-bit unsigned integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated, an exception is raised.
- */
 interface BigUint64Array {
   /** The size in bytes of each element in the array. */
   readonly BYTES_PER_ELEMENT: number;
@@ -591,7 +712,6 @@ interface BigUint64Array {
 
   /** Yields index, value pairs for every entry in the array. */
   entries(): IterableIterator<[number, bigint]>;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -600,9 +720,14 @@ interface BigUint64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -614,7 +739,6 @@ interface BigUint64Array {
    * length+end.
    */
   fill(value: bigint, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -622,11 +746,15 @@ interface BigUint64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: bigint, index: number, array: BigUint64Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): BigUint64Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -636,11 +764,15 @@ interface BigUint64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): bigint | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -650,11 +782,15 @@ interface BigUint64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn A function that accepts up to three arguments. forEach calls the
@@ -662,9 +798,9 @@ interface BigUint64Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: bigint, index: number, array: BigUint64Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: bigint, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -702,7 +838,6 @@ interface BigUint64Array {
 
   /** The length of the array. */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -711,30 +846,30 @@ interface BigUint64Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: bigint, index: number, array: BigUint64Array) => bigint,
-    thisArg?: any
+  map<This = undefined>(
+    callbackfn: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => bigint,
+    thisArg?: This
   ): BigUint64Array;
-
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
    * call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
    * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
    */
-  reduce(
+  reduce<U = bigint>(
     callbackfn: (
-      previousValue: bigint,
+      previousValue: bigint | U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigUint64Array
-    ) => bigint
-  ): bigint;
-
+      array: this
+    ) => U
+  ): bigint | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -745,35 +880,30 @@ interface BigUint64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = bigint>(
     callbackfn: (
       previousValue: U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigUint64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = bigint>(
     callbackfn: (
-      previousValue: bigint,
+      previousValue: bigint | U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigUint64Array
-    ) => bigint
-  ): bigint;
-
+      array: this
+    ) => U
+  ): bigint | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -784,12 +914,12 @@ interface BigUint64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = bigint>(
     callbackfn: (
       previousValue: U,
       currentValue: bigint,
       currentIndex: number,
-      array: BigUint64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -810,7 +940,6 @@ interface BigUint64Array {
    * @param end The end of the specified portion of the array.
    */
   slice(start?: number, end?: number): BigUint64Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls the
@@ -819,9 +948,14 @@ interface BigUint64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: bigint, index: number, array: BigUint64Array) => boolean,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -856,6 +990,113 @@ interface BigUint64Array {
 
   [index: number]: bigint;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns false,
+//      * or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: bigint, index: number, array: BigUint64Array) => any, thisArg?: any): BigUint64Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): bigint | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: bigint, index: number, array: BigUint64Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: bigint, index: number, array: BigUint64Array) => bigint, thisArg?: any): BigUint64Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigUint64Array) => bigint): bigint;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigUint64Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: bigint, currentValue: bigint, currentIndex: number, array: BigUint64Array) => bigint): bigint;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: bigint, currentIndex: number, array: BigUint64Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls the
+//      * predicate function for each element in the array until the predicate returns true, or until
+//      * the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: bigint, index: number, array: BigUint64Array) => boolean, thisArg?: any): boolean;
 
 interface BigUint64ArrayConstructor {
   readonly prototype: BigUint64Array;
@@ -875,20 +1116,31 @@ interface BigUint64ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: bigint[]): BigUint64Array;
-
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param arrayLike An array-like or iterable object to convert to an array.
+   */
+  from(arrayLike: Iterable<bigint> | ArrayLike<bigint>): BigUint64Array;
   /**
    * Creates an array from an array-like or iterable object.
    * @param arrayLike An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from(arrayLike: ArrayLike<bigint>): BigUint64Array;
-  from<U>(
-    arrayLike: ArrayLike<U>,
-    mapfn: (v: U, k: number) => bigint,
-    thisArg?: any
+  from<T, This = undefined>(
+    arrayLike: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => bigint,
+    thisArg?: This
   ): BigUint64Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from(arrayLike: ArrayLike<bigint>): BigUint64Array;
+//     from<U>(arrayLike: ArrayLike<U>, mapfn: (v: U, k: number) => bigint, thisArg?: any): BigUint64Array;
 
 declare var BigUint64Array: BigUint64ArrayConstructor;
 

--- a/generated/lib.es2022.object.d.ts
+++ b/generated/lib.es2022.object.d.ts
@@ -14,7 +14,9 @@ interface ObjectConstructor {
     : symbol extends Key
     ? {}
     : Key extends PropertyKey
-    ? { [key in Key]: unknown }
+    ? {
+        [key in Key]: unknown;
+      }
     : {};
 }
 //     /**

--- a/generated/lib.es5.d.ts
+++ b/generated/lib.es5.d.ts
@@ -130,7 +130,9 @@ interface Object {
     : symbol extends Key
     ? {}
     : Key extends PropertyKey
-    ? { [key in Key]: unknown }
+    ? {
+        [key in Key]: unknown;
+      }
     : {};
 
   /**
@@ -163,7 +165,7 @@ interface ObjectConstructor {
    * Returns the prototype of an object.
    * @param o The object that references the prototype.
    */
-  getPrototypeOf(o: any): unknown;
+  getPrototypeOf<T>(o: T): CheckNonNullable<T, unknown>;
 
   /**
    * Gets the own property descriptor of the specified object.
@@ -171,17 +173,17 @@ interface ObjectConstructor {
    * @param o Object that contains the property.
    * @param p Name of the property.
    */
-  getOwnPropertyDescriptor(
-    o: any,
+  getOwnPropertyDescriptor<T>(
+    o: T,
     p: PropertyKey
-  ): PropertyDescriptor | undefined;
+  ): CheckNonNullable<T, PropertyDescriptor | undefined>;
 
   /**
    * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
    * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
    * @param o Object that contains the own properties.
    */
-  getOwnPropertyNames<O>(o: O): O extends undefined | null ? never : string[];
+  getOwnPropertyNames<T>(o: T): CheckNonNullable<T, string[]>;
 
   /**
    * Creates an object that has the specified prototype or that has null prototype.
@@ -204,9 +206,13 @@ interface ObjectConstructor {
     o: O,
     properties: P & ThisType<any>
   ): {
-    [K in keyof (O & P)]: P[K] extends { value: infer V }
+    [K in keyof (O & P)]: P[K] extends {
+      value: infer V;
+    }
       ? V
-      : P[K] extends { get: () => infer V }
+      : P[K] extends {
+          get: () => infer V;
+        }
       ? V
       : K extends keyof O
       ? O[K]
@@ -222,9 +228,13 @@ interface ObjectConstructor {
     o: null,
     properties: P & ThisType<any>
   ): {
-    [K in keyof P]: P[K] extends { value: infer V }
+    [K in keyof P]: P[K] extends {
+      value: infer V;
+    }
       ? V
-      : P[K] extends { get: () => infer V }
+      : P[K] extends {
+          get: () => infer V;
+        }
       ? V
       : unknown;
   };
@@ -246,9 +256,13 @@ interface ObjectConstructor {
   ): O &
     (P extends PropertyKey // required to make P distributive
       ? {
-          [K in P]: D extends { value: infer V }
+          [K in P]: D extends {
+            value: infer V;
+          }
             ? V
-            : D extends { get: () => infer V }
+            : D extends {
+                get: () => infer V;
+              }
             ? V
             : unknown;
         }
@@ -266,9 +280,13 @@ interface ObjectConstructor {
     o: O,
     properties: P & ThisType<any>
   ): {
-    [K in keyof (O & P)]: P[K] extends { value: infer V }
+    [K in keyof (O & P)]: P[K] extends {
+      value: infer V;
+    }
       ? V
-      : P[K] extends { get: () => infer V }
+      : P[K] extends {
+          get: () => infer V;
+        }
       ? V
       : K extends keyof O
       ? O[K]
@@ -337,6 +355,13 @@ interface ObjectConstructor {
 //      * @param o The object that references the prototype.
 //      */
 //     getPrototypeOf(o: any): any;
+//     /**
+//      * Gets the own property descriptor of the specified object.
+//      * An own property descriptor is one that is defined directly on the object and is not inherited from the object's prototype.
+//      * @param o Object that contains the property.
+//      * @param p Name of the property.
+//      */
+//     getOwnPropertyDescriptor(o: any, p: PropertyKey): PropertyDescriptor | undefined;
 //     /**
 //      * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly
 //      * on that object, and are not inherited from the object's prototype. The properties of an object include both fields (objects) and functions.
@@ -489,14 +514,9 @@ interface NewableFunction extends Function {
   /**
    * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
    * @param thisArg The object to be used as the this object.
-   */
-  apply<T>(this: new () => T, thisArg: T): void;
-
-  /**
-   * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
-   * @param thisArg The object to be used as the this object.
    * @param args An array of argument values to be passed to the function.
    */
+  apply<T>(this: new () => T, thisArg: T): void;
   apply<T, A extends any[]>(
     this: new (...args: A) => T,
     thisArg: T,
@@ -513,7 +533,6 @@ interface NewableFunction extends Function {
     thisArg: T,
     ...args: A
   ): void;
-
   /**
    * For a given function, creates a bound function that has the same body as the original function.
    * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
@@ -526,19 +545,6 @@ interface NewableFunction extends Function {
     ...args: A
   ): new (...args: B) => R;
 }
-//     /**
-//      * Calls the function with the specified object as the this value and the elements of specified array as the arguments.
-//      * @param thisArg The object to be used as the this object.
-//      * @param args An array of argument values to be passed to the function.
-//      */
-//     apply<T>(this: new () => T, thisArg: T): void;
-//     apply<T, A extends any[]>(this: new (...args: A) => T, thisArg: T, args: A): void;
-//     /**
-//      * Calls the function with the specified object as the this value and the specified rest arguments as the arguments.
-//      * @param thisArg The object to be used as the this object.
-//      * @param args Argument values to be passed to the function.
-//      */
-//     call<T, A extends any[]>(this: new (...args: A) => T, thisArg: T, ...args: A): void;
 //     /**
 //      * For a given function, creates a bound function that has the same body as the original function.
 //      * The this object of the bound function is associated with the specified object, and has the specified initial parameters.
@@ -1448,14 +1454,11 @@ interface ReadonlyArray<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   every<S extends T, This = undefined>(
-    predicate: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => value is S,
+    predicate: (this: This, value: T, index: number, array: this) => value is S,
     thisArg?: This
-  ): this is readonly S[];
+  ): this is {
+    [K in keyof this]: S;
+  };
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1465,12 +1468,7 @@ interface ReadonlyArray<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   every<This = undefined>(
-    predicate: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): boolean;
   /**
@@ -1482,12 +1480,7 @@ interface ReadonlyArray<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   some<This = undefined>(
-    predicate: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): boolean;
   /**
@@ -1496,12 +1489,7 @@ interface ReadonlyArray<T> {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
    */
   forEach<This = undefined>(
-    callbackfn: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => void,
+    callbackfn: (this: This, value: T, index: number, array: this) => void,
     thisArg?: This
   ): void;
   /**
@@ -1510,21 +1498,18 @@ interface ReadonlyArray<T> {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
    */
   map<U, This = undefined>(
-    callbackfn: (this: This, value: T, index: number, array: readonly T[]) => U,
+    callbackfn: (this: This, value: T, index: number, array: this) => U,
     thisArg?: This
-  ): U[];
+  ): {
+    -readonly [K in keyof this]: U;
+  };
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
    * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
    */
   filter<S extends T, This = undefined>(
-    predicate: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => value is S,
+    predicate: (this: This, value: T, index: number, array: this) => value is S,
     thisArg?: This
   ): S[];
   /**
@@ -1533,83 +1518,58 @@ interface ReadonlyArray<T> {
    * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
    */
   filter<This = undefined>(
-    predicate: (
-      this: This,
-      value: T,
-      index: number,
-      array: readonly T[]
-    ) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): T[];
   /**
    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduce(
+  reduce<U = T>(
     callbackfn: (
-      previousValue: T,
+      previousValue: T | U,
       currentValue: T,
       currentIndex: number,
-      array: readonly T[]
-    ) => T
-  ): T;
-  reduce(
-    callbackfn: (
-      previousValue: T,
-      currentValue: T,
-      currentIndex: number,
-      array: readonly T[]
-    ) => T,
-    initialValue: T
-  ): T;
+      array: this
+    ) => U
+  ): T | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduce<U>(
+  reduce<U = T>(
     callbackfn: (
       previousValue: U,
       currentValue: T,
       currentIndex: number,
-      array: readonly T[]
+      array: this
     ) => U,
     initialValue: U
   ): U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = T>(
     callbackfn: (
-      previousValue: T,
+      previousValue: T | U,
       currentValue: T,
       currentIndex: number,
-      array: readonly T[]
-    ) => T
-  ): T;
-  reduceRight(
-    callbackfn: (
-      previousValue: T,
-      currentValue: T,
-      currentIndex: number,
-      array: readonly T[]
-    ) => T,
-    initialValue: T
-  ): T;
+      array: this
+    ) => U
+  ): T | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = T>(
     callbackfn: (
       previousValue: U,
       currentValue: T,
       currentIndex: number,
-      array: readonly T[]
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -1667,6 +1627,32 @@ interface ReadonlyArray<T> {
 //      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
 //      */
 //     filter(predicate: (value: T, index: number, array: readonly T[]) => unknown, thisArg?: any): T[];
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T;
+//     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T): T;
+//     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: readonly T[]) => T, initialValue: T): T;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: readonly T[]) => U, initialValue: U): U;
 
 interface ConcatArray<T> {
   readonly length: number;
@@ -1751,7 +1737,7 @@ interface Array<T> {
    * @param deleteCount The number of elements to remove.
    * @returns An array containing the elements that were deleted.
    */
-  splice(start: number, deleteCount?: number): this;
+  splice(start: number, deleteCount?: number): T[];
   /**
    * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
    * @param start The zero-based location in the array from which to start removing elements.
@@ -1759,7 +1745,7 @@ interface Array<T> {
    * @param items Elements to insert into the array in place of the deleted elements.
    * @returns An array containing the elements that were deleted.
    */
-  splice(start: number, deleteCount: number, ...items: T[]): this;
+  splice(start: number, deleteCount: number, ...items: T[]): T[];
   /**
    * Inserts new elements at the start of an array, and returns the new length of the array.
    * @param items Elements to insert at the start of the array.
@@ -1786,9 +1772,11 @@ interface Array<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   every<S extends T, This = undefined>(
-    predicate: (this: This, value: T, index: number, array: T[]) => value is S,
+    predicate: (this: This, value: T, index: number, array: this) => value is S,
     thisArg?: This
-  ): this is S[];
+  ): this is {
+    [K in keyof this]: S;
+  };
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1798,7 +1786,7 @@ interface Array<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   every<This = undefined>(
-    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): boolean;
   /**
@@ -1810,7 +1798,7 @@ interface Array<T> {
    * If thisArg is omitted, undefined is used as the this value.
    */
   some<This = undefined>(
-    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): boolean;
   /**
@@ -1819,7 +1807,7 @@ interface Array<T> {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
    */
   forEach<This = undefined>(
-    callbackfn: (this: This, value: T, index: number, array: T[]) => void,
+    callbackfn: (this: This, value: T, index: number, array: this) => void,
     thisArg?: This
   ): void;
   /**
@@ -1828,16 +1816,18 @@ interface Array<T> {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
    */
   map<U, This = undefined>(
-    callbackfn: (this: This, value: T, index: number, array: T[]) => U,
+    callbackfn: (this: This, value: T, index: number, array: this) => U,
     thisArg?: This
-  ): U[];
+  ): {
+    [K in keyof this]: U;
+  };
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.
    * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
    */
   filter<S extends T, This = undefined>(
-    predicate: (this: This, value: T, index: number, array: T[]) => value is S,
+    predicate: (this: This, value: T, index: number, array: this) => value is S,
     thisArg?: This
   ): S[];
   /**
@@ -1846,99 +1836,64 @@ interface Array<T> {
    * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
    */
   filter<This = undefined>(
-    predicate: (this: This, value: T, index: number, array: T[]) => boolean,
+    predicate: (this: This, value: T, index: number, array: this) => boolean,
     thisArg?: This
   ): T[];
   /**
    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduce(
+  reduce<U = T>(
     callbackfn: (
-      previousValue: T,
+      previousValue: T | U,
       currentValue: T,
       currentIndex: number,
-      array: T[]
-    ) => T
-  ): T;
-  reduce(
-    callbackfn: (
-      previousValue: T,
-      currentValue: T,
-      currentIndex: number,
-      array: T[]
-    ) => T,
-    initialValue: T
-  ): T;
+      array: this
+    ) => U
+  ): T | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduce<U>(
+  reduce<U = T>(
     callbackfn: (
       previousValue: U,
       currentValue: T,
       currentIndex: number,
-      array: T[]
+      array: this
     ) => U,
     initialValue: U
   ): U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = T>(
     callbackfn: (
-      previousValue: T,
+      previousValue: T | U,
       currentValue: T,
       currentIndex: number,
-      array: T[]
-    ) => T
-  ): T;
-  reduceRight(
-    callbackfn: (
-      previousValue: T,
-      currentValue: T,
-      currentIndex: number,
-      array: T[]
-    ) => T,
-    initialValue: T
-  ): T;
+      array: this
+    ) => U
+  ): T | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
    * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = T>(
     callbackfn: (
       previousValue: U,
       currentValue: T,
       currentIndex: number,
-      array: T[]
+      array: this
     ) => U,
     initialValue: U
   ): U;
 
   [n: number]: T;
 }
-//     /**
-//      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-//      * @param start The zero-based location in the array from which to start removing elements.
-//      * @param deleteCount The number of elements to remove.
-//      * @returns An array containing the elements that were deleted.
-//      */
-//     splice(start: number, deleteCount?: number): T[];
-//     /**
-//      * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
-//      * @param start The zero-based location in the array from which to start removing elements.
-//      * @param deleteCount The number of elements to remove.
-//      * @param items Elements to insert into the array in place of the deleted elements.
-//      * @returns An array containing the elements that were deleted.
-//      */
-//     splice(start: number, deleteCount: number, ...items: T[]): T[];
 //     /**
 //      * Determines whether all the members of an array satisfy the specified test.
 //      * @param predicate A function that accepts up to three arguments. The every method calls
@@ -1990,6 +1945,32 @@ interface Array<T> {
 //      * @param thisArg An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value.
 //      */
 //     filter(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): T[];
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+//     reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T): T;
+//     reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue: T): T;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
 
 interface ArrayConstructor {
   new <T>(arrayLength: number): T[];
@@ -2417,11 +2398,6 @@ interface DataViewConstructor {
   ): DataView;
 }
 declare var DataView: DataViewConstructor;
-
-/**
- * A typed array of 8-bit integer values. The contents are initialized to 0. If the requested
- * number of bytes could not be allocated an exception is raised.
- */
 interface Int8Array {
   /**
    * The size in bytes of each element in the array.
@@ -2453,7 +2429,6 @@ interface Int8Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -2462,9 +2437,14 @@ interface Int8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Int8Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -2476,7 +2456,6 @@ interface Int8Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -2484,11 +2463,15 @@ interface Int8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Int8Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Int8Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -2498,11 +2481,10 @@ interface Int8Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Int8Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -2512,11 +2494,10 @@ interface Int8Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Int8Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -2524,9 +2505,9 @@ interface Int8Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Int8Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -2556,7 +2537,6 @@ interface Int8Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -2565,39 +2545,30 @@ interface Int8Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Int8Array) => number,
-    thisArg?: any
-  ): Int8Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int8Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int8Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Int8Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -2608,44 +2579,30 @@ interface Int8Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int8Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Int8Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int8Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -2656,12 +2613,12 @@ interface Int8Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int8Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -2684,7 +2641,6 @@ interface Int8Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Int8Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -2693,9 +2649,14 @@ interface Int8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Int8Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -2732,6 +2693,116 @@ interface Int8Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Int8Array) => any, thisArg?: any): Int8Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Int8Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Int8Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Int8Array) => number, thisArg?: any): Int8Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int8Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int8Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Int8Array) => unknown, thisArg?: any): boolean;
+
 interface Int8ArrayConstructor {
   readonly prototype: Int8Array;
   new (length: number): Int8Array;
@@ -2752,31 +2823,37 @@ interface Int8ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Int8Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Int8Array;
-
+  from(source: ArrayLike<number>): Int8Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int8Array;
 }
-declare var Int8Array: Int8ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Int8Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int8Array;
 
-/**
- * A typed array of 8-bit unsigned integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated an exception is raised.
- */
+declare var Int8Array: Int8ArrayConstructor;
 interface Uint8Array {
   /**
    * The size in bytes of each element in the array.
@@ -2808,7 +2885,6 @@ interface Uint8Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -2817,9 +2893,14 @@ interface Uint8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Uint8Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -2831,7 +2912,6 @@ interface Uint8Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -2839,11 +2919,15 @@ interface Uint8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Uint8Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Uint8Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -2853,11 +2937,10 @@ interface Uint8Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Uint8Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -2867,11 +2950,10 @@ interface Uint8Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Uint8Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -2879,9 +2961,9 @@ interface Uint8Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Uint8Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -2911,7 +2993,6 @@ interface Uint8Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -2920,39 +3001,30 @@ interface Uint8Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Uint8Array) => number,
-    thisArg?: any
-  ): Uint8Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Uint8Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -2963,44 +3035,30 @@ interface Uint8Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -3011,12 +3069,12 @@ interface Uint8Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -3039,7 +3097,6 @@ interface Uint8Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Uint8Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -3048,9 +3105,14 @@ interface Uint8Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Uint8Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3087,6 +3149,115 @@ interface Uint8Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Uint8Array) => any, thisArg?: any): Uint8Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Uint8Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Uint8Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Uint8Array) => number, thisArg?: any): Uint8Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Uint8Array) => unknown, thisArg?: any): boolean;
 
 interface Uint8ArrayConstructor {
   readonly prototype: Uint8Array;
@@ -3108,31 +3279,37 @@ interface Uint8ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Uint8Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Uint8Array;
-
+  from(source: ArrayLike<number>): Uint8Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint8Array;
 }
-declare var Uint8Array: Uint8ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Uint8Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8Array;
 
-/**
- * A typed array of 8-bit unsigned integer (clamped) values. The contents are initialized to 0.
- * If the requested number of bytes could not be allocated an exception is raised.
- */
+declare var Uint8Array: Uint8ArrayConstructor;
 interface Uint8ClampedArray {
   /**
    * The size in bytes of each element in the array.
@@ -3164,7 +3341,6 @@ interface Uint8ClampedArray {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -3173,13 +3349,14 @@ interface Uint8ClampedArray {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
+  every<This = undefined>(
     predicate: (
+      this: This,
       value: number,
       index: number,
-      array: Uint8ClampedArray
-    ) => unknown,
-    thisArg?: any
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3191,7 +3368,6 @@ interface Uint8ClampedArray {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -3199,11 +3375,15 @@ interface Uint8ClampedArray {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Uint8ClampedArray) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Uint8ClampedArray;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -3213,15 +3393,10 @@ interface Uint8ClampedArray {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (
-      value: number,
-      index: number,
-      obj: Uint8ClampedArray
-    ) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -3231,15 +3406,10 @@ interface Uint8ClampedArray {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (
-      value: number,
-      index: number,
-      obj: Uint8ClampedArray
-    ) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -3247,13 +3417,9 @@ interface Uint8ClampedArray {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (
-      value: number,
-      index: number,
-      array: Uint8ClampedArray
-    ) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -3283,7 +3449,6 @@ interface Uint8ClampedArray {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -3292,15 +3457,30 @@ interface Uint8ClampedArray {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
+  map<This = undefined>(
     callbackfn: (
+      this: This,
       value: number,
       index: number,
-      array: Uint8ClampedArray
+      array: this
     ) => number,
-    thisArg?: any
+    thisArg?: This
   ): Uint8ClampedArray;
-
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -3311,72 +3491,30 @@ interface Uint8ClampedArray {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8ClampedArray
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8ClampedArray
-    ) => number,
-    initialValue: number
-  ): number;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8ClampedArray
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8ClampedArray
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint8ClampedArray
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -3387,12 +3525,12 @@ interface Uint8ClampedArray {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint8ClampedArray
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -3415,7 +3553,6 @@ interface Uint8ClampedArray {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Uint8ClampedArray;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -3424,13 +3561,14 @@ interface Uint8ClampedArray {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
+  some<This = undefined>(
     predicate: (
+      this: This,
       value: number,
       index: number,
-      array: Uint8ClampedArray
-    ) => unknown,
-    thisArg?: any
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3467,6 +3605,115 @@ interface Uint8ClampedArray {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Uint8ClampedArray) => any, thisArg?: any): Uint8ClampedArray;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Uint8ClampedArray) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => number, thisArg?: any): Uint8ClampedArray;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Uint8ClampedArray) => unknown, thisArg?: any): boolean;
 
 interface Uint8ClampedArrayConstructor {
   readonly prototype: Uint8ClampedArray;
@@ -3488,31 +3735,37 @@ interface Uint8ClampedArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Uint8ClampedArray;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Uint8ClampedArray;
-
+  from(source: ArrayLike<number>): Uint8ClampedArray;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint8ClampedArray;
 }
-declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Uint8ClampedArray;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint8ClampedArray;
 
-/**
- * A typed array of 16-bit signed integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated an exception is raised.
- */
+declare var Uint8ClampedArray: Uint8ClampedArrayConstructor;
 interface Int16Array {
   /**
    * The size in bytes of each element in the array.
@@ -3544,7 +3797,6 @@ interface Int16Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -3553,9 +3805,14 @@ interface Int16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Int16Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3567,7 +3824,6 @@ interface Int16Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -3575,11 +3831,15 @@ interface Int16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Int16Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Int16Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -3589,11 +3849,10 @@ interface Int16Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Int16Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -3603,11 +3862,10 @@ interface Int16Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Int16Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -3615,9 +3873,9 @@ interface Int16Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Int16Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
   /**
    * Returns the index of the first occurrence of a value in an array.
@@ -3646,7 +3904,6 @@ interface Int16Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -3655,39 +3912,30 @@ interface Int16Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Int16Array) => number,
-    thisArg?: any
-  ): Int16Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int16Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int16Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Int16Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -3698,44 +3946,30 @@ interface Int16Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int16Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Int16Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int16Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -3746,12 +3980,12 @@ interface Int16Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int16Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -3774,7 +4008,6 @@ interface Int16Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Int16Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -3783,9 +4016,14 @@ interface Int16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Int16Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3822,6 +4060,115 @@ interface Int16Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Int16Array) => any, thisArg?: any): Int16Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Int16Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Int16Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Int16Array) => number, thisArg?: any): Int16Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int16Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int16Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Int16Array) => unknown, thisArg?: any): boolean;
 
 interface Int16ArrayConstructor {
   readonly prototype: Int16Array;
@@ -3843,31 +4190,37 @@ interface Int16ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Int16Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Int16Array;
-
+  from(source: ArrayLike<number>): Int16Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int16Array;
 }
-declare var Int16Array: Int16ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Int16Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int16Array;
 
-/**
- * A typed array of 16-bit unsigned integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated an exception is raised.
- */
+declare var Int16Array: Int16ArrayConstructor;
 interface Uint16Array {
   /**
    * The size in bytes of each element in the array.
@@ -3899,7 +4252,6 @@ interface Uint16Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -3908,9 +4260,14 @@ interface Uint16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Uint16Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -3922,7 +4279,6 @@ interface Uint16Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -3930,11 +4286,15 @@ interface Uint16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Uint16Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Uint16Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -3944,11 +4304,10 @@ interface Uint16Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Uint16Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -3958,11 +4317,10 @@ interface Uint16Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Uint16Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -3970,9 +4328,9 @@ interface Uint16Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Uint16Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -4002,7 +4360,6 @@ interface Uint16Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -4011,39 +4368,30 @@ interface Uint16Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Uint16Array) => number,
-    thisArg?: any
-  ): Uint16Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint16Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint16Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Uint16Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -4054,44 +4402,30 @@ interface Uint16Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint16Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Uint16Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint16Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -4102,12 +4436,12 @@ interface Uint16Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint16Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -4130,7 +4464,6 @@ interface Uint16Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Uint16Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -4139,9 +4472,14 @@ interface Uint16Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Uint16Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4178,6 +4516,115 @@ interface Uint16Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Uint16Array) => any, thisArg?: any): Uint16Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Uint16Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Uint16Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Uint16Array) => number, thisArg?: any): Uint16Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint16Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint16Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Uint16Array) => unknown, thisArg?: any): boolean;
 
 interface Uint16ArrayConstructor {
   readonly prototype: Uint16Array;
@@ -4199,30 +4646,37 @@ interface Uint16ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Uint16Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Uint16Array;
-
+  from(source: ArrayLike<number>): Uint16Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint16Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Uint16Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint16Array;
+
 declare var Uint16Array: Uint16ArrayConstructor;
-/**
- * A typed array of 32-bit signed integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated an exception is raised.
- */
 interface Int32Array {
   /**
    * The size in bytes of each element in the array.
@@ -4254,7 +4708,6 @@ interface Int32Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -4263,9 +4716,14 @@ interface Int32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Int32Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4277,7 +4735,6 @@ interface Int32Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -4285,11 +4742,15 @@ interface Int32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Int32Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Int32Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -4299,11 +4760,10 @@ interface Int32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Int32Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -4313,11 +4773,10 @@ interface Int32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Int32Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -4325,9 +4784,9 @@ interface Int32Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Int32Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -4357,7 +4816,6 @@ interface Int32Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -4366,39 +4824,30 @@ interface Int32Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Int32Array) => number,
-    thisArg?: any
-  ): Int32Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int32Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int32Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Int32Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -4409,44 +4858,30 @@ interface Int32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Int32Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Int32Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -4457,12 +4892,12 @@ interface Int32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Int32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -4485,7 +4920,6 @@ interface Int32Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Int32Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -4494,9 +4928,14 @@ interface Int32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Int32Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4533,6 +4972,115 @@ interface Int32Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Int32Array) => any, thisArg?: any): Int32Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Int32Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Int32Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Int32Array) => number, thisArg?: any): Int32Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int32Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int32Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Int32Array) => unknown, thisArg?: any): boolean;
 
 interface Int32ArrayConstructor {
   readonly prototype: Int32Array;
@@ -4554,31 +5102,37 @@ interface Int32ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Int32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Int32Array;
-
+  from(source: ArrayLike<number>): Int32Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Int32Array;
 }
-declare var Int32Array: Int32ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Int32Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Int32Array;
 
-/**
- * A typed array of 32-bit unsigned integer values. The contents are initialized to 0. If the
- * requested number of bytes could not be allocated an exception is raised.
- */
+declare var Int32Array: Int32ArrayConstructor;
 interface Uint32Array {
   /**
    * The size in bytes of each element in the array.
@@ -4610,7 +5164,6 @@ interface Uint32Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -4619,9 +5172,14 @@ interface Uint32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Uint32Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4633,7 +5191,6 @@ interface Uint32Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -4641,11 +5198,15 @@ interface Uint32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Uint32Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Uint32Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -4655,11 +5216,10 @@ interface Uint32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Uint32Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -4669,11 +5229,10 @@ interface Uint32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Uint32Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -4681,9 +5240,9 @@ interface Uint32Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Uint32Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
   /**
    * Returns the index of the first occurrence of a value in an array.
@@ -4712,7 +5271,6 @@ interface Uint32Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -4721,39 +5279,30 @@ interface Uint32Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Uint32Array) => number,
-    thisArg?: any
-  ): Uint32Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint32Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint32Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Uint32Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -4764,44 +5313,30 @@ interface Uint32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Uint32Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Uint32Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -4812,12 +5347,12 @@ interface Uint32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Uint32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -4840,7 +5375,6 @@ interface Uint32Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Uint32Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -4849,9 +5383,14 @@ interface Uint32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Uint32Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4888,6 +5427,115 @@ interface Uint32Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Uint32Array) => any, thisArg?: any): Uint32Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Uint32Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Uint32Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Uint32Array) => number, thisArg?: any): Uint32Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint32Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint32Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Uint32Array) => unknown, thisArg?: any): boolean;
 
 interface Uint32ArrayConstructor {
   readonly prototype: Uint32Array;
@@ -4909,31 +5557,37 @@ interface Uint32ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Uint32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Uint32Array;
-
+  from(source: ArrayLike<number>): Uint32Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Uint32Array;
 }
-declare var Uint32Array: Uint32ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Uint32Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Uint32Array;
 
-/**
- * A typed array of 32-bit float values. The contents are initialized to 0. If the requested number
- * of bytes could not be allocated an exception is raised.
- */
+declare var Uint32Array: Uint32ArrayConstructor;
 interface Float32Array {
   /**
    * The size in bytes of each element in the array.
@@ -4965,7 +5619,6 @@ interface Float32Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -4974,9 +5627,14 @@ interface Float32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Float32Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -4988,7 +5646,6 @@ interface Float32Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -4996,11 +5653,15 @@ interface Float32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Float32Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Float32Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -5010,11 +5671,10 @@ interface Float32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Float32Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -5024,11 +5684,10 @@ interface Float32Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Float32Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -5036,9 +5695,9 @@ interface Float32Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Float32Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -5068,7 +5727,6 @@ interface Float32Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -5077,39 +5735,30 @@ interface Float32Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Float32Array) => number,
-    thisArg?: any
-  ): Float32Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float32Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float32Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Float32Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -5120,44 +5769,30 @@ interface Float32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Float32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Float32Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float32Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -5168,12 +5803,12 @@ interface Float32Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Float32Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -5196,7 +5831,6 @@ interface Float32Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Float32Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -5205,9 +5839,14 @@ interface Float32Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Float32Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -5244,6 +5883,115 @@ interface Float32Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Float32Array) => any, thisArg?: any): Float32Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Float32Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Float32Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Float32Array) => number, thisArg?: any): Float32Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float32Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float32Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Float32Array) => unknown, thisArg?: any): boolean;
 
 interface Float32ArrayConstructor {
   readonly prototype: Float32Array;
@@ -5265,31 +6013,37 @@ interface Float32ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Float32Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Float32Array;
-
+  from(source: ArrayLike<number>): Float32Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Float32Array;
 }
-declare var Float32Array: Float32ArrayConstructor;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Float32Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float32Array;
 
-/**
- * A typed array of 64-bit float values. The contents are initialized to 0. If the requested
- * number of bytes could not be allocated an exception is raised.
- */
+declare var Float32Array: Float32ArrayConstructor;
 interface Float64Array {
   /**
    * The size in bytes of each element in the array.
@@ -5321,7 +6075,6 @@ interface Float64Array {
    * @param end If not specified, length of the this object is used as its default value.
    */
   copyWithin(target: number, start: number, end?: number): this;
-
   /**
    * Determines whether all the members of an array satisfy the specified test.
    * @param predicate A function that accepts up to three arguments. The every method calls
@@ -5330,9 +6083,14 @@ interface Float64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  every(
-    predicate: (value: number, index: number, array: Float64Array) => unknown,
-    thisArg?: any
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -5344,7 +6102,6 @@ interface Float64Array {
    * length+end.
    */
   fill(value: number, start?: number, end?: number): this;
-
   /**
    * Returns the elements of an array that meet the condition specified in a callback function.
    * @param predicate A function that accepts up to three arguments. The filter method calls
@@ -5352,11 +6109,15 @@ interface Float64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  filter(
-    predicate: (value: number, index: number, array: Float64Array) => any,
-    thisArg?: any
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): Float64Array;
-
   /**
    * Returns the value of the first element in the array where predicate is true, and undefined
    * otherwise.
@@ -5366,11 +6127,10 @@ interface Float64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  find(
-    predicate: (value: number, index: number, obj: Float64Array) => boolean,
-    thisArg?: any
+  find<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number | undefined;
-
   /**
    * Returns the index of the first element in the array where predicate is true, and -1
    * otherwise.
@@ -5380,11 +6140,10 @@ interface Float64Array {
    * @param thisArg If provided, it will be used as the this value for each invocation of
    * predicate. If it is not provided, undefined is used instead.
    */
-  findIndex(
-    predicate: (value: number, index: number, obj: Float64Array) => boolean,
-    thisArg?: any
+  findIndex<This = undefined>(
+    predicate: (this: This, value: number, index: number, obj: this) => boolean,
+    thisArg?: This
   ): number;
-
   /**
    * Performs the specified action for each element in an array.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the
@@ -5392,9 +6151,9 @@ interface Float64Array {
    * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  forEach(
-    callbackfn: (value: number, index: number, array: Float64Array) => void,
-    thisArg?: any
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: number, index: number, array: this) => void,
+    thisArg?: This
   ): void;
 
   /**
@@ -5424,7 +6183,6 @@ interface Float64Array {
    * The length of the array.
    */
   readonly length: number;
-
   /**
    * Calls a defined callback function on each element of an array, and returns an array that
    * contains the results.
@@ -5433,39 +6191,30 @@ interface Float64Array {
    * @param thisArg An object to which the this keyword can refer in the callbackfn function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  map(
-    callbackfn: (value: number, index: number, array: Float64Array) => number,
-    thisArg?: any
-  ): Float64Array;
-
-  /**
-   * Calls the specified callback function for all the elements in an array. The return value of
-   * the callback function is the accumulated result, and is provided as an argument in the next
-   * call to the callback function.
-   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
-   * callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an argument
-   * instead of an array value.
-   */
-  reduce(
+  map<This = undefined>(
     callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float64Array
-    ) => number
-  ): number;
-  reduce(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float64Array
+      this: This,
+      value: number,
+      index: number,
+      array: this
     ) => number,
-    initialValue: number
-  ): number;
-
+    thisArg?: This
+  ): Float64Array;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = number>(
+    callbackfn: (
+      previousValue: number | U,
+      currentValue: number,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array. The return value of
    * the callback function is the accumulated result, and is provided as an argument in the next
@@ -5476,44 +6225,30 @@ interface Float64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduce<U>(
+  reduce<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Float64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
-
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
    * argument in the next call to the callback function.
    * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
    * the callbackfn function one time for each element in the array.
-   * @param initialValue If initialValue is specified, it is used as the initial value to start
-   * the accumulation. The first call to the callbackfn function provides this value as an
-   * argument instead of an array value.
    */
-  reduceRight(
+  reduceRight<U = number>(
     callbackfn: (
-      previousValue: number,
+      previousValue: number | U,
       currentValue: number,
       currentIndex: number,
-      array: Float64Array
-    ) => number
-  ): number;
-  reduceRight(
-    callbackfn: (
-      previousValue: number,
-      currentValue: number,
-      currentIndex: number,
-      array: Float64Array
-    ) => number,
-    initialValue: number
-  ): number;
-
+      array: this
+    ) => U
+  ): number | U;
   /**
    * Calls the specified callback function for all the elements in an array, in descending order.
    * The return value of the callback function is the accumulated result, and is provided as an
@@ -5524,12 +6259,12 @@ interface Float64Array {
    * the accumulation. The first call to the callbackfn function provides this value as an argument
    * instead of an array value.
    */
-  reduceRight<U>(
+  reduceRight<U = number>(
     callbackfn: (
       previousValue: U,
       currentValue: number,
       currentIndex: number,
-      array: Float64Array
+      array: this
     ) => U,
     initialValue: U
   ): U;
@@ -5552,7 +6287,6 @@ interface Float64Array {
    * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
    */
   slice(start?: number, end?: number): Float64Array;
-
   /**
    * Determines whether the specified callback function returns true for any element of an array.
    * @param predicate A function that accepts up to three arguments. The some method calls
@@ -5561,9 +6295,14 @@ interface Float64Array {
    * @param thisArg An object to which the this keyword can refer in the predicate function.
    * If thisArg is omitted, undefined is used as the this value.
    */
-  some(
-    predicate: (value: number, index: number, array: Float64Array) => unknown,
-    thisArg?: any
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: number,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
   ): boolean;
 
   /**
@@ -5591,6 +6330,115 @@ interface Float64Array {
 
   [index: number]: number;
 }
+//     /**
+//      * Determines whether all the members of an array satisfy the specified test.
+//      * @param predicate A function that accepts up to three arguments. The every method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value false, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     every(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
+//     /**
+//      * Returns the elements of an array that meet the condition specified in a callback function.
+//      * @param predicate A function that accepts up to three arguments. The filter method calls
+//      * the predicate function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     filter(predicate: (value: number, index: number, array: Float64Array) => any, thisArg?: any): Float64Array;
+//     /**
+//      * Returns the value of the first element in the array where predicate is true, and undefined
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found, find
+//      * immediately returns that element value. Otherwise, find returns undefined.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     find(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number | undefined;
+//     /**
+//      * Returns the index of the first element in the array where predicate is true, and -1
+//      * otherwise.
+//      * @param predicate find calls predicate once for each element of the array, in ascending
+//      * order, until it finds one where predicate returns true. If such an element is found,
+//      * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+//      * @param thisArg If provided, it will be used as the this value for each invocation of
+//      * predicate. If it is not provided, undefined is used instead.
+//      */
+//     findIndex(predicate: (value: number, index: number, obj: Float64Array) => boolean, thisArg?: any): number;
+//     /**
+//      * Performs the specified action for each element in an array.
+//      * @param callbackfn  A function that accepts up to three arguments. forEach calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg  An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     forEach(callbackfn: (value: number, index: number, array: Float64Array) => void, thisArg?: any): void;
+//     /**
+//      * Calls a defined callback function on each element of an array, and returns an array that
+//      * contains the results.
+//      * @param callbackfn A function that accepts up to three arguments. The map method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     map(callbackfn: (value: number, index: number, array: Float64Array) => number, thisArg?: any): Float64Array;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number): number;
+//     reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array. The return value of
+//      * the callback function is the accumulated result, and is provided as an argument in the next
+//      * call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+//      * callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float64Array) => U, initialValue: U): U;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an
+//      * argument instead of an array value.
+//      */
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number): number;
+//     reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number, initialValue: number): number;
+//     /**
+//      * Calls the specified callback function for all the elements in an array, in descending order.
+//      * The return value of the callback function is the accumulated result, and is provided as an
+//      * argument in the next call to the callback function.
+//      * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+//      * the callbackfn function one time for each element in the array.
+//      * @param initialValue If initialValue is specified, it is used as the initial value to start
+//      * the accumulation. The first call to the callbackfn function provides this value as an argument
+//      * instead of an array value.
+//      */
+//     reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float64Array) => U, initialValue: U): U;
+//     /**
+//      * Determines whether the specified callback function returns true for any element of an array.
+//      * @param predicate A function that accepts up to three arguments. The some method calls
+//      * the predicate function for each element in the array until the predicate returns a value
+//      * which is coercible to the Boolean value true, or until the end of the array.
+//      * @param thisArg An object to which the this keyword can refer in the predicate function.
+//      * If thisArg is omitted, undefined is used as the this value.
+//      */
+//     some(predicate: (value: number, index: number, array: Float64Array) => unknown, thisArg?: any): boolean;
 
 interface Float64ArrayConstructor {
   readonly prototype: Float64Array;
@@ -5612,25 +6460,36 @@ interface Float64ArrayConstructor {
    * @param items A set of elements to include in the new array object.
    */
   of(...items: number[]): Float64Array;
-
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    */
-  from(arrayLike: ArrayLike<number>): Float64Array;
-
+  from(source: ArrayLike<number>): Float64Array;
   /**
    * Creates an array from an array-like or iterable object.
-   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param source An array-like or iterable object to convert to an array.
    * @param mapfn A mapping function to call on every element of the array.
    * @param thisArg Value of 'this' used to invoke the mapfn.
    */
-  from<T>(
-    arrayLike: ArrayLike<T>,
-    mapfn: (v: T, k: number) => number,
-    thisArg?: any
+  from<T, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
   ): Float64Array;
 }
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      */
+//     from(arrayLike: ArrayLike<number>): Float64Array;
+//     /**
+//      * Creates an array from an array-like or iterable object.
+//      * @param arrayLike An array-like or iterable object to convert to an array.
+//      * @param mapfn A mapping function to call on every element of the array.
+//      * @param thisArg Value of 'this' used to invoke the mapfn.
+//      */
+//     from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): Float64Array;
+
 declare var Float64Array: Float64ArrayConstructor;
 
 /////////////////////////////
@@ -5828,6 +6687,8 @@ type UnionToIntersection<T> = (
 ) extends (arg: infer F) => void
   ? F
   : unknown;
+
+type CheckNonNullable<T, U> = [T] extends [NonNullable<T>] ? U : never;
 
 type JSONValue =
   | null

--- a/lib/lib.es2015.collection.d.ts
+++ b/lib/lib.es2015.collection.d.ts
@@ -1,6 +1,6 @@
 interface Map<K, V> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: V, key: K, map: Map<K, V>) => void,
+    callbackfn: (this: This, value: V, key: K, map: this) => void,
     thisArg?: This
   ): void;
 }
@@ -19,14 +19,14 @@ interface WeakMapConstructor {
 
 interface ReadonlyMap<K, V> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: V, key: K, map: ReadonlyMap<K, V>) => void,
+    callbackfn: (this: This, value: V, key: K, map: this) => void,
     thisArg?: This
   ): void;
 }
 
 interface Set<T> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: T, value2: T, set: Set<T>) => void,
+    callbackfn: (this: This, value: T, value2: T, set: this) => void,
     thisArg?: This
   ): void;
 }
@@ -38,7 +38,7 @@ interface SetConstructor {
 
 interface ReadonlySet<T> {
   forEach<This = undefined>(
-    callbackfn: (this: This, value: T, value2: T, set: ReadonlySet<T>) => void,
+    callbackfn: (this: This, value: T, value2: T, set: this) => void,
     thisArg?: This
   ): void;
 }

--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -1,3 +1,67 @@
+interface Array<T> {
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<S extends T, This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => value is S,
+    thisArg?: This
+  ): S | undefined;
+
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
+  ): T | undefined;
+
+  /**
+   * Returns the index of the first element in the array where predicate is true, and -1
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found,
+   * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  findIndex<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
+  ): number;
+}
+
+interface ArrayConstructor {
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from<T>(source: ArrayLike<T>): T[];
+
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   * @param mapfn A mapping function to call on every element of the array.
+   * @param thisArg Value of 'this' used to invoke the mapfn.
+   */
+  from<T, U, This = undefined>(
+    source: ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => U,
+    thisArg?: This
+  ): U[];
+}
+
 interface NumberConstructor {
   /**
    * Returns true if passed value is finite.
@@ -38,7 +102,10 @@ interface ObjectConstructor {
   assign<T, Ts extends readonly any[]>(
     target: T,
     ...sources: Ts
-  ): First<UnionToIntersection<[T] | { [K in keyof Ts]: [Ts[K]] }[number]>>;
+  ): CheckNonNullable<
+    T,
+    First<UnionToIntersection<[T] | { [K in keyof Ts]: [Ts[K]] }[number]>>
+  >;
 
   /**
    * Returns true if the values are the same value, false otherwise.
@@ -60,6 +127,50 @@ interface ObjectConstructor {
    * @param proto The value of the new prototype or null.
    */
   setPrototypeOf<T extends object>(o: T, proto: null): T;
+}
+
+interface ReadonlyArray<T> {
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<S extends T, This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => value is S,
+    thisArg?: This
+  ): S | undefined;
+
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
+  ): T | undefined;
+
+  /**
+   * Returns the index of the first element in the array where predicate is true, and -1
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found,
+   * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  findIndex<This = undefined>(
+    predicate: (this: This, value: T, index: number, obj: this) => boolean,
+    thisArg?: This
+  ): number;
 }
 
 interface String {

--- a/lib/lib.es2015.iterable.d.ts
+++ b/lib/lib.es2015.iterable.d.ts
@@ -9,6 +9,26 @@ interface IterableIterator<T> extends Iterator<T, undefined, void> {
   [Symbol.iterator](): IterableIterator<T>;
 }
 
+interface ArrayConstructor {
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from<T>(source: Iterable<T> | ArrayLike<T>): T[];
+
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   * @param mapfn A mapping function to call on every element of the array.
+   * @param thisArg Value of 'this' used to invoke the mapfn.
+   */
+  from<T, U, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => U,
+    thisArg?: This
+  ): U[];
+}
+
 interface IArguments {
   /** Iterator */
   [Symbol.iterator](): IterableIterator<unknown>;
@@ -34,4 +54,23 @@ interface PromiseConstructor {
 
 interface MapConstructor {
   new <K, V>(iterable?: Iterable<readonly [K, V]> | null): Map<K, V>;
+}
+
+interface TypedNumberArrayConstructor {
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   */
+  from(source: Iterable<number> | ArrayLike<number>): TypedNumberArray;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param source An array-like or iterable object to convert to an array.
+   * @param mapfn A mapping function to call on every element of the array.
+   * @param thisArg Value of 'this' used to invoke the mapfn.
+   */
+  from<T, This = undefined>(
+    source: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => number,
+    thisArg?: This
+  ): TypedNumberArray;
 }

--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -13,7 +13,7 @@ interface ObjectConstructor {
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  values(o: unknown): unknown[];
+  values<T>(o: T): CheckNonNullable<T, unknown[]>;
 
   /**
    * Returns an array of key/values of the enumerable properties of an object
@@ -29,5 +29,16 @@ interface ObjectConstructor {
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<T>(o: T): [string, unknown][];
+  entries<T>(o: T): CheckNonNullable<T, [string, unknown][]>;
+
+  /**
+   * Returns an object containing all own property descriptors of an object
+   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+   */
+  getOwnPropertyDescriptors<T>(o: T): CheckNonNullable<
+    T,
+    { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & {
+      [x: string]: PropertyDescriptor;
+    }
+  >;
 }

--- a/lib/lib.es2020.bigint.d.ts
+++ b/lib/lib.es2020.bigint.d.ts
@@ -1,0 +1,203 @@
+interface TypedBigIntArray {
+  /**
+   * Determines whether all the members of an array satisfy the specified test.
+   * @param predicate A function that accepts up to three arguments. The every method calls
+   * the predicate function for each element in the array until the predicate returns false,
+   * or until the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function.
+   * If thisArg is omitted, undefined is used as the this value.
+   */
+  every<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
+  ): boolean;
+  /**
+   * Returns the elements of an array that meet the condition specified in a callback function.
+   * @param predicate A function that accepts up to three arguments. The filter method calls
+   * the predicate function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function.
+   * If thisArg is omitted, undefined is used as the this value.
+   */
+  filter<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
+  ): TypedBigIntArray;
+  /**
+   * Returns the value of the first element in the array where predicate is true, and undefined
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found, find
+   * immediately returns that element value. Otherwise, find returns undefined.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  find<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
+  ): bigint | undefined;
+  /**
+   * Returns the index of the first element in the array where predicate is true, and -1
+   * otherwise.
+   * @param predicate find calls predicate once for each element of the array, in ascending
+   * order, until it finds one where predicate returns true. If such an element is found,
+   * findIndex immediately returns that element index. Otherwise, findIndex returns -1.
+   * @param thisArg If provided, it will be used as the this value for each invocation of
+   * predicate. If it is not provided, undefined is used instead.
+   */
+  findIndex<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
+  ): number;
+  /**
+   * Performs the specified action for each element in an array.
+   * @param callbackfn A function that accepts up to three arguments. forEach calls the
+   * callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+   * If thisArg is omitted, undefined is used as the this value.
+   */
+  forEach<This = undefined>(
+    callbackfn: (this: This, value: bigint, index: number, array: this) => void,
+    thisArg?: This
+  ): void;
+  /**
+   * Calls a defined callback function on each element of an array, and returns an array that
+   * contains the results.
+   * @param callbackfn A function that accepts up to three arguments. The map method calls the
+   * callbackfn function one time for each element in the array.
+   * @param thisArg An object to which the this keyword can refer in the callbackfn function.
+   * If thisArg is omitted, undefined is used as the this value.
+   */
+  map<This = undefined>(
+    callbackfn: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => bigint,
+    thisArg?: This
+  ): TypedBigIntArray;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   */
+  reduce<U = bigint>(
+    callbackfn: (
+      previousValue: bigint | U,
+      currentValue: bigint,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): bigint | U;
+  /**
+   * Calls the specified callback function for all the elements in an array. The return value of
+   * the callback function is the accumulated result, and is provided as an argument in the next
+   * call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduce method calls the
+   * callbackfn function one time for each element in the array.
+   * @param initialValue If initialValue is specified, it is used as the initial value to start
+   * the accumulation. The first call to the callbackfn function provides this value as an argument
+   * instead of an array value.
+   */
+  reduce<U = bigint>(
+    callbackfn: (
+      previousValue: U,
+      currentValue: bigint,
+      currentIndex: number,
+      array: this
+    ) => U,
+    initialValue: U
+  ): U;
+  /**
+   * Calls the specified callback function for all the elements in an array, in descending order.
+   * The return value of the callback function is the accumulated result, and is provided as an
+   * argument in the next call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+   * the callbackfn function one time for each element in the array.
+   */
+  reduceRight<U = bigint>(
+    callbackfn: (
+      previousValue: bigint | U,
+      currentValue: bigint,
+      currentIndex: number,
+      array: this
+    ) => U
+  ): bigint | U;
+  /**
+   * Calls the specified callback function for all the elements in an array, in descending order.
+   * The return value of the callback function is the accumulated result, and is provided as an
+   * argument in the next call to the callback function.
+   * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls
+   * the callbackfn function one time for each element in the array.
+   * @param initialValue If initialValue is specified, it is used as the initial value to start
+   * the accumulation. The first call to the callbackfn function provides this value as an argument
+   * instead of an array value.
+   */
+  reduceRight<U = bigint>(
+    callbackfn: (
+      previousValue: U,
+      currentValue: bigint,
+      currentIndex: number,
+      array: this
+    ) => U,
+    initialValue: U
+  ): U;
+  /**
+   * Determines whether the specified callback function returns true for any element of an array.
+   * @param predicate A function that accepts up to three arguments. The some method calls the
+   * predicate function for each element in the array until the predicate returns true, or until
+   * the end of the array.
+   * @param thisArg An object to which the this keyword can refer in the predicate function.
+   * If thisArg is omitted, undefined is used as the this value.
+   */
+  some<This = undefined>(
+    predicate: (
+      this: This,
+      value: bigint,
+      index: number,
+      array: this
+    ) => boolean,
+    thisArg?: This
+  ): boolean;
+}
+
+interface TypedBigIntArrayConstructor {
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param arrayLike An array-like or iterable object to convert to an array.
+   */
+  from(arrayLike: Iterable<bigint> | ArrayLike<bigint>): TypedBigIntArray;
+  /**
+   * Creates an array from an array-like or iterable object.
+   * @param arrayLike An array-like or iterable object to convert to an array.
+   * @param mapfn A mapping function to call on every element of the array.
+   * @param thisArg Value of 'this' used to invoke the mapfn.
+   */
+  from<T, This = undefined>(
+    arrayLike: Iterable<T> | ArrayLike<T>,
+    mapfn: (this: This, v: T, k: number) => bigint,
+    thisArg?: This
+  ): TypedBigIntArray;
+}

--- a/tests/src/es2015.core.ts
+++ b/tests/src/es2015.core.ts
@@ -1,4 +1,20 @@
-import { expectType } from "tsd";
+import { expectError, expectType } from "tsd";
+
+// ReadonlyArray
+{
+  // https://github.com/uhyo/better-typescript-lib/issues/7
+  const a1: readonly number[] = [1, 2, 3];
+  expectError(a1.find((x) => x));
+  expectError(a1.findIndex((x) => x));
+}
+
+// Array
+{
+  // https://github.com/uhyo/better-typescript-lib/issues/7
+  const a1: number[] = [1, 2, 3];
+  expectError(a1.find((x) => x));
+  expectError(a1.findIndex((x) => x));
+}
 
 // NumberConstructor
 {
@@ -17,8 +33,10 @@ import { expectType } from "tsd";
     expectType<number>(n);
   }
 }
+
 // ObjectConstructor
 {
+  expectType<never>(Object.assign(null));
   const obj1 = Object.assign({ foo: 123 });
   expectType<{ foo: number }>(obj1);
   const obj2 = Object.assign({ foo: 123 }, { bar: "wow" });

--- a/tests/src/es2017.object.ts
+++ b/tests/src/es2017.object.ts
@@ -8,6 +8,10 @@ function createGenericRecord<K extends string, V>(
 }
 
 {
+  expectType<never>(Object.values(null));
+  expectType<never>(Object.entries(null));
+  expectType<never>(Object.getOwnPropertyDescriptors(null));
+
   const obj1: { [k: string]: number } = { foo: 123 };
   const values1 = Object.values(obj1);
   const entries1 = Object.entries(obj1);

--- a/tests/src/es2020.bigint.ts
+++ b/tests/src/es2020.bigint.ts
@@ -1,0 +1,12 @@
+import { expectError } from "tsd";
+// TypedNumberArray
+{
+  for (const TypedBigIntArray of [BigInt64Array, BigUint64Array]) {
+    const a1 = new TypedBigIntArray();
+    expectError(a1.filter((x) => x));
+    expectError(a1.every((x) => x));
+    expectError(a1.some((x) => x));
+    expectError(a1.find((x) => x));
+    expectError(a1.findIndex((x) => x));
+  }
+}

--- a/tests/src/es5.ts
+++ b/tests/src/es5.ts
@@ -6,9 +6,16 @@ expectType<unknown>(eval("foo"));
 expectType<{}>(Object());
 expectType<{ foo: number }>(Object({ foo: 123 }));
 expectType<{}>(Object(123));
-// $ExpctType unknown
+// Object.getPrototypeOf
 expectType<unknown>(Object.getPrototypeOf([]));
+expectType<never>(Object.getPrototypeOf(null));
+// Object.getOwnPropertyDescriptor
+expectType<PropertyDescriptor | undefined>(
+  Object.getOwnPropertyDescriptor([], "foo")
+);
+expectType<never>(Object.getOwnPropertyDescriptor(null, "foo"));
 // Object.getOwnPropertyNames
+expectType<string[]>(Object.getOwnPropertyNames([]));
 expectType<never>(Object.getOwnPropertyNames(null));
 // Object.create
 expectType<{}>(Object.create(null));
@@ -177,30 +184,78 @@ expectType<{ foo: number; bar: string; baz: boolean }>(
 {
   // https://github.com/uhyo/better-typescript-lib/issues/7
   const a1: readonly number[] = [1, 2, 3];
-  expectType<number[]>(a1.filter((a1) => a1 > 2));
+  expectType<number[]>(a1.filter((x) => x > 2));
   expectType<1[]>(a1.filter((x): x is 1 => x === 1));
   if (a1.every((x): x is 2 => x === 2)) {
     expectType<readonly 2[]>(a1);
   }
+  expectType<string | number>(
+    a1.reduce((x) => {
+      expectType<string | number>(x);
+      return "foo";
+    })
+  );
+  expectType<string>(
+    a1.reduce((x) => {
+      expectType<string>(x);
+      return "foo";
+    }, "foo")
+  );
+  expectType<typeof a1["reduce"]>(a1.reduceRight);
 
   expectError(a1.filter((x) => x));
   expectError(a1.every((x) => x));
   expectError(a1.some((x) => x));
+
+  const a2: readonly [number, number, number] = [1, 2, 3];
+  if (
+    a2.every((x, i, a3): x is 2 => {
+      expectType<typeof a2>(a3);
+      return x === 2;
+    })
+  ) {
+    expectType<readonly [2, 2, 2]>(a2);
+  }
+  expectType<[string, string, string]>(a2.map(() => "foo"));
 }
 
 // Array
 {
   // https://github.com/uhyo/better-typescript-lib/issues/7
   const a1: number[] = [1, 2, 3];
-  expectType<number[]>(a1.filter((a1) => a1 > 2));
+  expectType<number[]>(a1.filter((x) => x > 2));
   expectType<1[]>(a1.filter((x): x is 1 => x === 1));
   if (a1.every((x): x is 2 => x === 2)) {
     expectType<2[]>(a1);
   }
+  expectType<string | number>(
+    a1.reduce((x) => {
+      expectType<string | number>(x);
+      return "foo";
+    })
+  );
+  expectType<string>(
+    a1.reduce((x) => {
+      expectType<string>(x);
+      return "foo";
+    }, "foo")
+  );
+  expectType<typeof a1["reduce"]>(a1.reduceRight);
 
   expectError(a1.filter((x) => x));
   expectError(a1.every((x) => x));
   expectError(a1.some((x) => x));
+
+  const a2: [number, number, number] = [1, 2, 3];
+  if (
+    a2.every((x, i, a3): x is 2 => {
+      expectType<typeof a2>(a3);
+      return x === 2;
+    })
+  ) {
+    expectType<[2, 2, 2]>(a2);
+  }
+  expectType<[string, string, string]>(a2.map(() => "foo"));
 }
 
 // ArrayConstructor
@@ -229,6 +284,28 @@ expectType<{ foo: number; bar: string; baz: boolean }>(
   }
   if (Array.isArray(a8)) {
     expectType<unknown>(a8[0]);
+  }
+}
+
+// TypedNumberArray
+{
+  for (const TypedNumberArray of [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+  ]) {
+    const a1 = new TypedNumberArray();
+    expectError(a1.filter((x) => x));
+    expectError(a1.every((x) => x));
+    expectError(a1.some((x) => x));
+    expectError(a1.find((x) => x));
+    expectError(a1.findIndex((x) => x));
   }
 }
 


### PR DESCRIPTION
Sorry for another PR! Unlike the previous (closed) one, this PR should be mergeable without any external actions required.

This PR brings type safety to typed array and extends #7 to the `find` and `findIndex` methods.

Introduces a single utility type `CheckNonNullable`, which is unnecessary with the type of `o` being replaced to `{}` after TypeScript 4.8 due to https://github.com/microsoft/TypeScript/pull/49119.

The first parameter of `{Array, %TypedArray%}.from` are all renamed to `source` because writing `iterable: Iterable<T> | ArrayLike<T>` is kind of misleading, and it is also named `source` in [the spec text](https://tc39.es/ecma262/#sec-array.from).

This PR does not include tests for methods with only `thisArg` changes, or it will be superfluous.

I think some bugs like `this: void` in the original library files should be reported to TypeScript, and I am surprised that the return type of the first parameter of the `%TypedArray%.prototype` methods in the original `es2020.bigint.d.ts` file are already typed `boolean`, in contrast to the `Array.prototype` methods in `es5.d.ts`.