### PR TITLE
refactor: Change return type of Object.entries from [string, V] to [K, V]

### DIFF
--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -24,7 +24,7 @@ interface ObjectConstructor {
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<K extends PropertyKey, V>(o: Record<K, V>): [string, V][];
+  entries<K extends PropertyKey, V>(o: Record<K, V>): [K, V][];
   /**
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.


### PR DESCRIPTION
Currently, the return value of `Object.entries` is [string, V], which is weakly typed when extracted by subsequent `map`, etc.
Therefore, we propose to return [K,V] so that the type of the key can be inferred.

However, we do not consider other detailed use cases. If it is not appropriate, please CLOSE.

## Supplemental
I ran the test and it mocked up loudly🤯.