### PR TITLE
Add better type definitions for Promise onrejected

### DIFF
--- a/generated/lib.es5.d.ts
+++ b/generated/lib.es5.d.ts
@@ -2121,19 +2121,17 @@ interface Promise<T> extends PromiseLike<T> {
    * @param onrejected The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of which ever callback is executed.
    */
-  then<U>(
+  then<U, R = never>(
     onfulfilled: (value: T) => U | PromiseLike<U>,
-    onrejected?: ((reason: unknown) => U | PromiseLike<U>) | null | undefined
-  ): Promise<U>;
+    onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null | undefined
+  ): Promise<U | R>;
 
   /**
    * Attaches a callback for only the rejection of the Promise.
    * @param onrejected The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of the callback.
    */
-  catch(
-    onrejected?: ((reason: unknown) => T | PromiseLike<T>) | null | undefined
-  ): Promise<T>;
+  catch<U>(onrejected: (reason: unknown) => U | PromiseLike<U>): Promise<T | U>;
 }
 // /**
 //  * Represents the completion of an asynchronous operation

--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -622,19 +622,19 @@ interface Promise<T> extends PromiseLike<T> {
    * @param onrejected The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of which ever callback is executed.
    */
-  then<U>(
+  then<U, R = never>(
     onfulfilled: (value: T) => U | PromiseLike<U>,
-    onrejected?: ((reason: unknown) => U | PromiseLike<U>) | null | undefined
-  ): Promise<U>;
+    onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null | undefined
+  ): Promise<U | R>;
 
   /**
    * Attaches a callback for only the rejection of the Promise.
    * @param onrejected The callback to execute when the Promise is rejected.
    * @returns A Promise for the completion of the callback.
    */
-  catch(
-    onrejected?: ((reason: unknown) => T | PromiseLike<T>) | null | undefined
-  ): Promise<T>;
+  catch<U>(
+    onrejected: (reason: unknown) => U | PromiseLike<U>
+  ): Promise<T | U>;
 }
 
 interface TypedNumberArray {

--- a/tests/src/es5.ts
+++ b/tests/src/es5.ts
@@ -40,11 +40,8 @@ const testPromiseConstructorLike = (MyPromise: PromiseConstructorLike) => {
 // Promise
 const testPromise = (promise: Promise<string>) => {
   expectType<Promise<string>>(promise.then());
-  expectType<Promise<string>>(promise.catch());
   expectType<Promise<string>>(promise.then(null));
   expectType<Promise<string>>(promise.then(undefined));
-  expectType<Promise<string>>(promise.catch(null));
-  expectType<Promise<string>>(promise.catch(undefined));
   expectType<Promise<string>>(promise.then(null, null));
   expectType<Promise<string>>(promise.then(null, undefined));
   expectType<Promise<string>>(promise.then(undefined, null));
@@ -70,6 +67,24 @@ const testPromise = (promise: Promise<string>) => {
       (err) => Promise.resolve(`${err}`.length)
     )
   );
+  expectType<Promise<number | string>>(
+    promise.then(
+      (str) => str.length,
+      (err) => `${err}`
+    )
+  );
+  expectType<Promise<number | string>>(
+    promise.then(
+      (str) => str.length,
+      (err) => Promise.resolve(`${err}`)
+    )
+  );
+  expectType<Promise<number | string>>(
+    promise.then((str) => str.length).catch((err) => `${err}`)
+  );
+  expectType<Promise<number | string>>(
+    promise.then((str) => str.length).catch((err) => Promise.resolve(`${err}`))
+  );
   // @ts-expect-error
   promise.then<number>((str: string) => str);
   promise.then<number>(
@@ -81,6 +96,12 @@ const testPromise = (promise: Promise<string>) => {
   promise.then(null, (err) => `${err}`.length);
   // @ts-expect-error
   promise.catch(null, (err) => `${err}`.length);
+  // @ts-expect-error
+  promise.catch();
+  // @ts-expect-error
+  promise.catch(null);
+  // @ts-expect-error
+  promise.catch(undefined);
 };
 
 // eval
@@ -490,4 +511,5 @@ expectType<{ foo: number; bar: string; baz: boolean }>(
   }
 }
 
-export {};
+export { };
+


### PR DESCRIPTION
#32

Made a few changes:

1. promise.catch is not allowed to accept `null` `undefined` and is not `optional`
2. The final type is the union type of onfulfilled and onrejected