### PR TITLE
fix: tighten up Object.values and Object.entries types

### DIFF
--- a/docs/diff/es2017.object.d.ts.md
+++ b/docs/diff/es2017.object.d.ts.md
@@ -5,7 +5,7 @@ Index: es2017.object.d.ts
 ===================================================================
 --- es2017.object.d.ts
 +++ es2017.object.d.ts
-@@ -2,34 +2,44 @@
+@@ -2,34 +2,48 @@
    /**
     * Returns an array of values of the enumerable properties of an object
     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -18,7 +18,9 @@ Index: es2017.object.d.ts
     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
     */
 -  values(o: {}): any[];
-+  values<K extends PropertyKey, V>(o: Record<K, V>): V[];
++  values<K extends PropertyKey, V>(
++    o: Record<K, V>,
++  ): (string extends K ? V : number extends K ? V : unknown)[];
 +  /**
 +   * Returns an array of values of the enumerable properties of an object
 +   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -37,7 +39,9 @@ Index: es2017.object.d.ts
     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
     */
 -  entries(o: {}): [string, any][];
-+  entries<K extends PropertyKey, V>(o: Record<K, V>): [string, V][];
++  entries<K extends PropertyKey, V>(
++    o: Record<K, V>,
++  ): [string, string extends K ? V : number extends K ? V : unknown][];
 +  /**
 +   * Returns an array of key/values of the enumerable properties of an object
 +   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.

--- a/generated/lib.es2017.object.d.ts
+++ b/generated/lib.es2017.object.d.ts
@@ -9,7 +9,9 @@ interface ObjectConstructor {
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  values<K extends PropertyKey, V>(o: Record<K, V>): V[];
+  values<K extends PropertyKey, V>(
+    o: Record<K, V>,
+  ): (string extends K ? V : number extends K ? V : unknown)[];
   /**
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -25,7 +27,9 @@ interface ObjectConstructor {
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<K extends PropertyKey, V>(o: Record<K, V>): [string, V][];
+  entries<K extends PropertyKey, V>(
+    o: Record<K, V>,
+  ): [string, string extends K ? V : number extends K ? V : unknown][];
   /**
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.

--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -8,7 +8,9 @@ interface ObjectConstructor {
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  values<K extends PropertyKey, V>(o: Record<K, V>): V[];
+  values<K extends PropertyKey, V>(
+    o: Record<K, V>,
+  ): (string extends K ? V : number extends K ? V : unknown)[];
   /**
    * Returns an array of values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
@@ -24,7 +26,9 @@ interface ObjectConstructor {
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
    */
-  entries<K extends PropertyKey, V>(o: Record<K, V>): [string, V][];
+  entries<K extends PropertyKey, V>(
+    o: Record<K, V>,
+  ): [string, string extends K ? V : number extends K ? V : unknown][];
   /**
    * Returns an array of key/values of the enumerable properties of an object
    * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.

--- a/tests/src/es2017.object.ts
+++ b/tests/src/es2017.object.ts
@@ -33,14 +33,14 @@ function createGenericRecord<K extends string, V>(
   const obj4 = createGenericRecord(["foo", "bar", "baz"], [1, 2, 3]);
   const values4 = Object.values(obj4);
   const entries4 = Object.entries(obj4);
-  expectType<number[]>(values4);
-  expectType<[string, number][]>(entries4);
+  expectType<unknown[]>(values4);
+  expectType<[string, unknown][]>(entries4);
 
   const obj5 = createGenericRecord(["foo", "bar", "baz"], [1, obj1, 3]);
   const values5 = Object.values(obj5);
   const entries5 = Object.entries(obj5);
-  expectType<(number | { [k: string]: number })[]>(values5);
-  expectType<[string, number | { [k: string]: number }][]>(entries5);
+  expectType<unknown[]>(values5);
+  expectType<[string, unknown][]>(entries5);
 }
 function test(obj: Record<string, unknown>) {
   const values = Object.values(obj);
@@ -49,4 +49,20 @@ function test(obj: Record<string, unknown>) {
   const entries = Object.entries(obj);
   expectType<string>(entries[0][0]);
   expectType<unknown>(entries[0][1]);
+}
+
+{
+  // https://github.com/uhyo/better-typescript-lib/issues/40
+  const obj: {} = {};
+  const obj2 = { foo: 123 };
+  const values = Object.values(obj);
+  const values2 = Object.values(obj2);
+  expectType<unknown[]>(values);
+  expectType<unknown[]>(values2);
+
+  const entries = Object.entries(obj);
+  const entries2 = Object.entries(obj2);
+
+  expectType<[string, unknown][]>(entries);
+  expectType<[string, unknown][]>(entries2);
 }


### PR DESCRIPTION
closes #40 

This fix tightens up `Object.values` and `Object.entries` types so that:

- `Object.values({})` returns `unknown[]` (previously `never[]`)
- `Object.values({ foo: 123 })` returns `unknown[]` (previously `number[]`)

To get non-`unknown[]` results you need to pass a value of type `Record<string, T>`.

```ts
const obj: Record<string, number> = { foo: 123 };

Object.values(obj) // number[]
```

This isn't still perfect but less unsafe than before.