### PR TITLE
fix: improve `NodeListOf<T>`#item return type to include null

### DIFF
--- a/docs/diff/dom.generated.d.ts.md
+++ b/docs/diff/dom.generated.d.ts.md
@@ -151,6 +151,17 @@ Index: dom.generated.d.ts
  }
  
  declare var MIDIOutputMap: {
+@@ -19085,9 +19107,9 @@
+   new (): NodeList;
+ };
+ 
+ interface NodeListOf<TNode extends Node> extends NodeList {
+-  item(index: number): TNode;
++  item(index: number): TNode | null;
+   /**
+    * Performs the specified action for each node in an list.
+    * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+    * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
 @@ -21527,11 +21549,11 @@
  };
  

--- a/generated/lib.dom.d.ts
+++ b/generated/lib.dom.d.ts
@@ -19118,7 +19118,7 @@ declare var NodeList: {
 };
 
 interface NodeListOf<TNode extends Node> extends NodeList {
-  item(index: number): TNode;
+  item(index: number): TNode | null;
   /**
    * Performs the specified action for each node in an list.
    * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
@@ -19130,6 +19130,7 @@ interface NodeListOf<TNode extends Node> extends NodeList {
   ): void;
   [index: number]: TNode;
 }
+//     item(index: number): TNode;
 
 interface NonDocumentTypeChildNode {
   /**

--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -218,3 +218,7 @@ declare function structuredClone<
   value: T,
   options?: StructuredSerializeOptions,
 ): BetterTypeScriptLibInternals.StructuredClone.StructuredCloneOutput<T>;
+
+interface NodeListOf<TNode extends Node> extends NodeList {
+  item(index: number): TNode | null;
+}

--- a/tests/src/dom.ts
+++ b/tests/src/dom.ts
@@ -137,3 +137,14 @@ const test = async (url: string) => {
     }
   }
 }
+
+// NodeListOf
+{
+  // https://github.com/uhyo/better-typescript-lib/issues/43
+  const list: NodeListOf<HTMLDivElement> = document.querySelectorAll("div");
+
+  const item = list.item(100);
+  expectType<HTMLDivElement | null>(item);
+  // @ts-expect-error
+  item.append("a");
+}


### PR DESCRIPTION
closes #43