### PR TITLE
build:package: fix windows paths in generated package.json

### DIFF
--- a/build/package.ts
+++ b/build/package.ts
@@ -106,7 +106,7 @@ async function main() {
             `file:${path.relative(
               path.dirname(packageJsonPath),
               path.join(packageDir, packageName),
-            )}`,
+            ).replace(/\\/g, "/")}`,
           ]),
         ),
       },


### PR DESCRIPTION
Running `npm run build:package` on Windows generates relative file paths with backslashes in `tests/package.json`.