### PR TITLE
fix: preserve call signatures of target object in Object.assign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This project generates alternative TypeScript standard library definitions with improved type safety. The architecture consists of:
 
 - **`build/`** - TypeScript build system and generation logic
+
   - `lib.ts` - Main script for generating improved lib definitions
   - `package.ts` - Script for building npm packages
   - `diff.ts` - Script for generating documentation diffs
@@ -25,6 +26,7 @@ This project generates alternative TypeScript standard library definitions with 
 ## Essential Commands
 
 ### Build Commands
+
 ```bash
 # Compile TypeScript build scripts
 npm run build:tsc
@@ -40,6 +42,9 @@ npm run build:diff
 ```
 
 ### Testing
+
+NOTE that you should run `npm run build:lib` and then `npm run build:package` before running tests to ensure the latest changes are reflected.
+
 ```bash
 # Run type-level tests in tests/ directory
 cd tests && npm test
@@ -49,10 +54,12 @@ cd tests && npx tsd
 ```
 
 ### Development Workflow
+
 1. Modify type definitions in `lib/` directory
-2. Run `npm run build:tsc && npm run build:lib` to regenerate
+2. Run `npm run build:lib && npm run build:generate` to regenerate the output
 3. Test changes with `cd tests && npm test`
-4. Generate packages with `npm run build:package` if needed
+
+NOTE that the generated type definitions only take effect during the tests. When you want to debug the generated types, the only way is to write a test case in the `tests/` directory and run `npm test` to see how the types behave. Do not forget to run `npm run build:lib && npm run build:generate` after modifying the source definitions in `lib/`.
 
 ## Key Implementation Details
 
@@ -63,7 +70,8 @@ cd tests && npx tsd
 - All changes prioritize type safety over convenience, potentially causing breaking changes in existing codebases
 
 ## Important Files
+
 - `build/logic/generate.ts` - Core generation algorithm
-- `build/logic/ReplacementMap.ts` - Tracks lib modifications  
+- `build/logic/ReplacementMap.ts` - Tracks lib modifications
 - `lib/es5.d.ts` - Main improvements to core JavaScript APIs
 - `tests/src/` - Type-level tests for verifications

--- a/generated/lib.es2015.core.d.ts
+++ b/generated/lib.es2015.core.d.ts
@@ -328,7 +328,7 @@ interface ObjectConstructor {
   assign<T extends {}, Ts extends readonly any[]>(
     target: T,
     ...sources: Ts
-  ): Intersect<[T, ...Ts]>;
+  ): T & Intersect<Ts>;
 
   /**
    * Returns an array of all symbol properties found directly on object o.

--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -72,7 +72,7 @@ interface ObjectConstructor {
   assign<T extends {}, Ts extends readonly any[]>(
     target: T,
     ...sources: Ts
-  ): Intersect<[T, ...Ts]>;
+  ): T & Intersect<Ts>;
 
   /**
    * Returns an array of all symbol properties found directly on object o.

--- a/tests/src/es2015.core.ts
+++ b/tests/src/es2015.core.ts
@@ -34,4 +34,19 @@ import { expectError, expectType } from "tsd";
   expectError(Object.getOwnPropertySymbols(null));
   const obj5 = Object.setPrototypeOf({ foo: 123 }, { bar: "wow" });
   expectType<{ foo: number } & { bar: string }>(obj5);
+
+  // https://github.com/uhyo/better-typescript-lib/issues/71
+  // Object.assign should preserve function callability
+  const func1 = () => 42;
+  const funcWithProps = Object.assign(func1, { baz: "hello" });
+  expectType<(() => number) & { baz: string }>(funcWithProps);
+  expectType<number>(funcWithProps()); // Should be callable
+  expectType<string>(funcWithProps.baz); // Should have the added property
+
+  const func2 = function(x: number): string { return x.toString(); };
+  const funcWithProps2 = Object.assign(func2, { value: 123 }, { flag: true });
+  expectType<((x: number) => string) & { value: number } & { flag: boolean }>(funcWithProps2);
+  expectType<string>(funcWithProps2(42)); // Should be callable
+  expectType<number>(funcWithProps2.value); // Should have added properties
+  expectType<boolean>(funcWithProps2.flag);
 }


### PR DESCRIPTION
fixes #71